### PR TITLE
Add support for OpenAI background requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.1.0)
+    ai-chat (0.1.1)
       base64 (~> 0.1)
       mime-types (~> 3.0)
-      openai (~> 0.14)
-      refinements (~> 11.1)
+      openai (~> 0.16)
       zeitwerk (~> 2.7)
+    openai (0.16.0)
+      connection_pool
 
 GEM
   remote: https://rubygems.org/
@@ -67,8 +68,6 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0729)
-    openai (0.15.0)
-      connection_pool
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -169,6 +168,7 @@ DEPENDENCIES
   dotenv
   rake (~> 13.3)
   reek (~> 6.5)
+  refinements (~> 11.1)
   repl_type_completor (~> 0.1)
   rspec (~> 3.13)
   simplecov (~> 0.22)

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 3.2"
   spec.add_dependency "zeitwerk", "~> 2.7"
-  spec.add_dependency "openai", "~> 0.14"
+  spec.add_dependency "openai", "~> 0.16"
   spec.add_runtime_dependency "mime-types", "~> 3.0"
   spec.add_runtime_dependency "base64", "~> 0.1"  # Works for all Ruby versions
 

--- a/lib/ai/response.rb
+++ b/lib/ai/response.rb
@@ -1,12 +1,13 @@
 module AI
   class Response
-    attr_reader :id, :model, :usage, :total_tokens
+    attr_reader :id, :model, :usage, :total_tokens, :status
 
     def initialize(response)
       @id = response.id
       @model = response.model
       @usage = response.usage.to_h.slice(:input_tokens, :output_tokens, :total_tokens)
       @total_tokens = @usage[:total_tokens]
+      @status = response.respond_to?(:status) ? response.status : nil
     end
   end
 end


### PR DESCRIPTION
- Upgrade OpenAI gem dependency from 0.14 to 0.16 to access responses API.
- Add background attribute to AI::Chat for enabling async requests.
- Implement polling mechanism in generate! for background requests.
- Add wait_for_response method with optional progress indicators.
- Update Response class to include status field.
- Support both synchronous and asynchronous request modes.

This enables long-running requests (e.g., o3-deep-research) to run in the background with automatic polling until completion. Progress can be shown with generate!(show_progress: true).

Resolves #4 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for asynchronous OpenAI requests with background processing and polling in `AI::Chat`.
> 
>   - **Behavior**:
>     - Upgrade OpenAI gem from 0.14 to 0.16 in `ai-chat.gemspec` for responses API access.
>     - Add `background` attribute to `AI::Chat` for async requests.
>     - Implement polling in `generate!` for background requests in `lib/ai/chat.rb`.
>     - Add `wait_for_response` method with progress indicators in `lib/ai/chat.rb`.
>     - Update `Response` class in `lib/ai/response.rb` to include `status` field.
>     - Support both sync and async request modes.
>   - **Misc**:
>     - Handle long-running requests with automatic polling until completion.
>     - Show progress with `generate!(show_progress: true)`.
>     - Resolves issue #4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 971880f0121f5161dd8c25c60f8fb03fd15dfba4. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->