### PR TITLE
Change multiturn image example

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,13 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.2.0)
+    ai-chat (0.2.1)
       base64 (> 0.1.1)
       json (~> 2.0)
       marcel (~> 1.0)
       openai (~> 0.16)
+    openai (0.16.0)
+      connection_pool
 
 GEM
   remote: https://rubygems.org/
@@ -63,8 +65,6 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     marcel (1.0.4)
-    openai (0.16.0)
-      connection_pool
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -91,7 +91,7 @@ GEM
       rainbow (>= 2.0, < 4.0)
       rexml (~> 3.1)
     refinements (11.1.1)
-    regexp_parser (2.10.0)
+    regexp_parser (2.11.0)
     reline (0.6.2)
       io-console (~> 0.5)
     repl_type_completor (0.1.11)
@@ -155,8 +155,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  arm64-darwin-23
-  ruby
+  arm64-darwin-24
 
 DEPENDENCIES
   ai-chat!

--- a/examples/12_image_generation.rb
+++ b/examples/12_image_generation.rb
@@ -39,15 +39,19 @@ b.generate!
 puts "Second image: #{b.messages.last[:images]}"
 puts
 
-puts "Example 3: Ghiblify - Transform an image to Studio Ghibli style"
+puts "Example 3: Multiturn image editing"
 puts "-" * 50
 c = AI::Chat.new
 c.image_generation = true
 image_path = File.expand_path("../spec/fixtures/thing.jpg", __dir__)
-puts "User: #{c.user("Transform this image into Studio Ghibli animation style", image: image_path)}"
+puts "User: #{c.user("Transform this image to look like watercolor", image: image_path)}"
 c.generate!
 puts "Assistant: #{c.messages.last[:content]}"
-puts "Ghiblified image: #{c.messages.last[:images]}"
+puts "Watercolor image: #{c.messages.last[:images]}"
+puts "User: #{c.user("Now make it black & white")}"
+c.generate!
+puts "Assistant: #{c.messages.last[:content]}"
+puts "Black and white image: #{c.messages.last[:images]}"
 puts
 
 puts "=== Image Generation Examples Complete ==="


### PR DESCRIPTION
Changes the multiturn image example to something less likely to be flagged by model guard rails.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modifies multiturn image example in `examples/12_image_generation.rb` to use "watercolor" and "black & white" transformations.
> 
>   - **Behavior**:
>     - Changes image transformation request in `examples/12_image_generation.rb` from "Studio Ghibli animation style" to "watercolor".
>     - Adds additional transformation step to "black & white" in the same example.
>   - **Misc**:
>     - Updates example description from "Ghiblify" to "Multiturn image editing".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 10700eb16356ac1a3b9335609a4e87529e3a1a16. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->