### PR TITLE
Enable background mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       json (~> 2.0)
       marcel (~> 1.0)
       openai (~> 0.16)
+      tty-spinner (~> 0.9.3)
 
 GEM
   remote: https://rubygems.org/
@@ -149,6 +150,9 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
     stringio (3.1.7)
+    tty-cursor (0.7.1)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "marcel", "~> 1.0"
   spec.add_runtime_dependency "base64", "> 0.1.1"
   spec.add_runtime_dependency "json", "~> 2.0"
+  spec.add_runtime_dependency "tty-spinner", "~> 0.9.3"
 
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "refinements", "~> 11.1"

--- a/examples/14_background_mode.rb
+++ b/examples/14_background_mode.rb
@@ -30,9 +30,6 @@ puts "#{message[:status] == :completed ? "✓ " : "✗"} Assistant message statu
 puts "#{chat.messages.select { |msg| msg[:role] == "assistant"}.count == 1 ? "✓ " : "✗"} Messages contains exactly 1 Assistant message."
 puts "#{!message[:content].empty? ? "✓ " : "✗"} Assistant message is present: #{message[:status]}"
 
-# ap chat.messages
-
-
 puts "\n" * 2
 puts "=" * 24
 puts "\n" * 2
@@ -40,13 +37,13 @@ puts "\n" * 2
 puts "2. Automatic polling"
 b = AI::Chat.new
 b.background = true
-b.user("Write a short description about a sci-fi novel about a rat in space.")
+b.user("Write a long description about a sci-fi novel about a rat in space.")
 b.generate!
 
 puts "\n" * 2
 message = b.get_response(wait: true)
 puts "\n" * 2
-puts "Assistant message: #{message[:content]}"
+puts "Assistant message: #{message[:content].inspect}"
 
 puts "\n" * 2
 puts "=== Background Mode Examples Complete ==="

--- a/examples/14_background_mode.rb
+++ b/examples/14_background_mode.rb
@@ -1,0 +1,53 @@
+require_relative "../lib/ai-chat"
+require "dotenv"
+Dotenv.load(File.expand_path("../.env", __dir__))
+require "amazing_print"
+
+
+# Example showcasing background mode capabilities
+puts "=== AI::Chat Background Mode Examples ==="
+puts
+puts "1. Manual polling:"
+chat = AI::Chat.new
+chat.background = true
+chat.user("Write a short description about a sci-fi novel about a rat in space.")
+chat.generate!
+
+message = chat.get_response
+
+puts "#{message.is_a?(Hash) ? "✓ " : "✗"} get_response returns a Hash: #{message.class}"
+puts "#{message[:status] != :completed ? "✓ " : "✗"} Assistant message status is: #{message[:status]}"
+puts "#{message[:content].empty? ? "✓ " : "✗"} Assistant message is empty: #{message[:content].inspect}"
+
+puts
+puts "manually waiting before polling again"
+puts
+sleep 10
+
+message = chat.get_response
+
+puts "#{message[:status] == :completed ? "✓ " : "✗"} Assistant message status is: #{message[:status]}"
+puts "#{chat.messages.select { |msg| msg[:role] == "assistant"}.count == 1 ? "✓ " : "✗"} Messages contains exactly 1 Assistant message."
+puts "#{!message[:content].empty? ? "✓ " : "✗"} Assistant message is present: #{message[:status]}"
+
+# ap chat.messages
+
+
+puts "\n" * 2
+puts "=" * 24
+puts "\n" * 2
+
+puts "2. Automatic polling"
+b = AI::Chat.new
+b.background = true
+b.user("Write a short description about a sci-fi novel about a rat in space.")
+b.generate!
+
+puts "\n" * 2
+message = b.get_response(wait: true)
+puts "\n" * 2
+puts "Assistant message: #{message[:content]}"
+
+puts "\n" * 2
+puts "=== Background Mode Examples Complete ==="
+puts "\n" * 4

--- a/examples/14_background_mode.rb
+++ b/examples/14_background_mode.rb
@@ -16,7 +16,7 @@ chat.generate!
 message = chat.get_response
 
 puts "#{message.is_a?(Hash) ? "✓ " : "✗"} get_response returns a Hash: #{message.class}"
-puts "#{message[:status] != :completed ? "✓ " : "✗"} Assistant message status is: #{message[:status]}"
+puts "#{message[:status] != :completed ? "✓ " : "✗"} Assistant message status is: #{message[:status].inspect}"
 puts "#{message[:content].empty? ? "✓ " : "✗"} Assistant message is empty: #{message[:content].inspect}"
 
 puts
@@ -26,9 +26,9 @@ sleep 10
 
 message = chat.get_response
 
-puts "#{message[:status] == :completed ? "✓ " : "✗"} Assistant message status is: #{message[:status]}"
+puts "#{message[:status] == :completed ? "✓ " : "✗"} Assistant message status is: #{message[:status].inspect}"
 puts "#{chat.messages.select { |msg| msg[:role] == "assistant"}.count == 1 ? "✓ " : "✗"} Messages contains exactly 1 Assistant message."
-puts "#{!message[:content].empty? ? "✓ " : "✗"} Assistant message is present: #{message[:status]}"
+puts "#{!message[:content].empty? ? "✓ " : "✗"} Assistant message is present: #{message[:content].inspect}"
 
 puts "\n" * 2
 puts "=" * 24
@@ -37,14 +37,30 @@ puts "\n" * 2
 puts "2. Automatic polling"
 b = AI::Chat.new
 b.background = true
-b.user("Write a long description about a sci-fi novel about a rat in space.")
+b.user("Write a short description about a sci-fi novel about a rat in space.")
 b.generate!
 
 puts "\n" * 2
 message = b.get_response(wait: true)
 puts "\n" * 2
 puts "Assistant message: #{message[:content].inspect}"
+puts "Assistant message status: #{message[:status].inspect}"
+
+puts "\n" * 4
+
+puts "3. Timeout"
+b = AI::Chat.new
+b.background = true
+b.user("Write a long description about a sci-fi novel about cheese in space.")
+b.generate!
+
+puts "\n" * 2
+message = b.get_response(wait: true, timeout: 3)
+puts "\n" * 2
+
+puts "Cancelled message: #{message[:content].inspect}"
+puts "Message status: #{message[:status].inspect}"
 
 puts "\n" * 2
 puts "=== Background Mode Examples Complete ==="
-puts "\n" * 4
+puts "\n" * 2

--- a/examples/all.rb
+++ b/examples/all.rb
@@ -47,3 +47,6 @@ require_relative "12_image_generation"
 
 # Code Interpreter
 require_relative "13_code_interpreter"
+
+# Background Mode
+require_relative "14_background_mode"

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -214,7 +214,11 @@ module AI
       client.responses.create(**parameters)
     end
 
-    def get_response(wait: false, timeout: )
+    # :reek:BooleanParameter
+    # :reek:ControlParameter
+    # :reek:DuplicateMethodCall
+    # :reek:TooManyStatements
+    def get_response(wait: false)
       response = if wait
         spinner = TTY::Spinner.new("[:spinner] Loading ...", format: :dots)
         spinner.auto_spin
@@ -234,6 +238,8 @@ module AI
       parse_response(response)
     end
 
+    # :reek:NilCheck
+    # :reek:TooManyStatements
     def parse_response(response)
       text_response = response.output_text
       image_filenames = extract_and_save_images(response)
@@ -552,6 +558,8 @@ module AI
     end
 
     # This is similar to ActiveJob's :polynomially_longer retry option
+    # :reek:DuplicateMethodCall
+    # :reek:UtilityFunction
     def calculate_wait(executions)
       # cap the maximum wait time to ~110 seconds
       executions = executions.clamp(1..10)

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -585,7 +585,8 @@ module AI
           end
           api_response
         end
-        exit_message = response.status == "cancelled" ? "request timed out" : "done!"
+
+        exit_message = response.status == :cancelled ? "request timed out" : "done!"
         spinner.stop(exit_message)
         response
     end

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -7,6 +7,7 @@ require "openai"
 require "pathname"
 require "stringio"
 require "fileutils"
+require "tty-spinner"
 
 module AI
   # :reek:MissingSafeMethod { exclude: [ generate! ] }
@@ -16,7 +17,7 @@ module AI
   # :reek:IrresponsibleModule
   class Chat
     # :reek:Attribute
-    attr_accessor :messages, :model, :web_search, :previous_response_id, :image_generation, :image_folder, :code_interpreter
+    attr_accessor :background, :code_interpreter, :image_generation, :image_folder, :messages, :model, :previous_response_id, :web_search
     attr_reader :reasoning_effort, :client, :schema
 
     VALID_REASONING_EFFORTS = [:low, :medium, :high].freeze
@@ -34,15 +35,16 @@ module AI
 
     # :reek:TooManyStatements
     # :reek:NilCheck
-    def add(content, role: "user", response: nil, image: nil, images: nil, file: nil, files: nil)
+    def add(content, role: "user", response: nil, status: nil, image: nil, images: nil, file: nil, files: nil)
       if image.nil? && images.nil? && file.nil? && files.nil?
-        messages.push(
-          {
-            role: role,
-            content: content,
-            response: response
-          }.compact
-        )
+        message = {
+          role: role,
+          content: content,
+          response: response
+        }
+        message[:content] = content if content
+        message[:status] = status if status
+        messages.push(message)
       else
         text_and_files_array = [
           {
@@ -75,7 +77,8 @@ module AI
         messages.push(
           {
             role: role,
-            content: text_and_files_array
+            content: text_and_files_array,
+            status: status
           }
         )
       end
@@ -88,52 +91,18 @@ module AI
     def user(message, image: nil, images: nil, file: nil, files: nil)
       add(message, role: "user", image: image, images: images, file: file, files: files)
     end
-
-    def assistant(message, response: nil)
-      add(message, role: "assistant", response: response)
+    
+    def assistant(message, response: nil, status: nil)
+      add(message, role: "assistant", response: response, status: status)
     end
 
     # :reek:NilCheck
     # :reek:TooManyStatements
     def generate!
       response = create_response
+      parse_response(response)
 
-      text_response = response.output_text
-
-      image_filenames = extract_and_save_images(response) + extract_and_save_files(response)
-      response_usage = response.usage.to_h.slice(:input_tokens, :output_tokens, :total_tokens)
-
-      chat_response = {
-        id: response.id,
-        model: response.model,
-        usage: response_usage,
-        total_tokens: response_usage[:total_tokens],
-        images: image_filenames
-      }
-
-      message = if schema
-        if text_response.nil? || text_response.empty?
-          raise ArgumentError, "No text content in response to parse as JSON for schema: #{schema.inspect}"
-        end
-        JSON.parse(text_response, symbolize_names: true)
-      else
-        text_response
-      end
-
-      if image_filenames.empty?
-        assistant(message, response: chat_response)
-      else
-        messages.push(
-          {
-            role: "assistant",
-            content: message,
-            images: image_filenames,
-            response: chat_response
-          }.compact
-        )
-      end
-
-      self.previous_response_id = chat_response[:id]
+      self.previous_response_id = last.dig(:response, :id)
       last
     end
 
@@ -233,6 +202,7 @@ module AI
         model: model
       }
 
+      parameters[:background] = background if background
       parameters[:tools] = tools unless tools.empty?
       parameters[:text] = schema if schema
       parameters[:reasoning] = {effort: reasoning_effort} if reasoning_effort
@@ -242,6 +212,71 @@ module AI
       parameters[:input] = strip_responses(messages_to_send) unless messages_to_send.empty?
 
       client.responses.create(**parameters)
+    end
+
+    def get_response(wait: false, timeout: )
+      response = if wait
+        spinner = TTY::Spinner.new("[:spinner] Loading ...", format: :dots)
+        spinner.auto_spin
+        api_response = client.responses.retrieve(previous_response_id)
+        number_of_times_polled = 0
+        while api_response.status != :completed
+          some_amount_of_seconds = calculate_wait(number_of_times_polled)
+          sleep some_amount_of_seconds
+          api_response = client.responses.retrieve(previous_response_id)
+          number_of_times_polled += 1
+        end
+        spinner.stop("Complete!")
+        api_response
+      else
+        client.responses.retrieve(previous_response_id)
+      end
+      parse_response(response)
+    end
+
+    def parse_response(response)
+      text_response = response.output_text
+      image_filenames = extract_and_save_images(response)
+      status = background.nil? ? nil : response.status
+      response_id = response.id
+      response_usage = response.usage.to_h.slice(:input_tokens, :output_tokens, :total_tokens)
+
+      chat_response = {
+        id: response_id,
+        model: response.model,
+        usage: response_usage,
+        total_tokens: response_usage[:total_tokens],
+        images: image_filenames
+      }.compact
+
+      response_content = if schema
+        if text_response.nil? || text_response.empty?
+          raise ArgumentError, "No text content in response to parse as JSON for schema: #{schema.inspect}"
+        end
+        JSON.parse(text_response, symbolize_names: true)
+      else
+        text_response
+      end
+
+      existing_message_position = messages.find_index do |message|
+        message.dig(:response, :id) == response_id
+      end
+
+      message = {
+        role: "assistant",
+        content: response_content,
+        response: chat_response,
+        status: status
+      }
+
+      message.store(:images, image_filenames) unless image_filenames.empty?
+
+      if existing_message_position
+        messages[existing_message_position] = message
+      else
+        messages.push(message)
+        message
+      end
     end
 
     def prepare_messages_for_api
@@ -514,6 +549,14 @@ module AI
       end
 
       filenames
+    end
+
+    # This is similar to ActiveJob's :polynomially_longer retry option
+    def calculate_wait(executions)
+      # cap the maximum wait time to ~110 seconds
+      executions = executions.clamp(1..10)
+      jitter = 0.15
+      ((executions**2) + (Kernel.rand * (executions**2) * jitter)) + 2
     end
   end
 end

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -233,7 +233,6 @@ module AI
     def parse_response(response)
       text_response = response.output_text
       image_filenames = extract_and_save_images(response)
-      status = background.nil? ? nil : response.status
       response_id = response.id
       response_usage = response.usage.to_h.slice(:input_tokens, :output_tokens, :total_tokens)
 
@@ -262,7 +261,7 @@ module AI
         role: "assistant",
         content: response_content,
         response: chat_response,
-        status: status
+        status: response.status
       }
 
       message.store(:images, image_filenames) unless image_filenames.empty?

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -92,7 +92,7 @@ module AI
     def user(message, image: nil, images: nil, file: nil, files: nil)
       add(message, role: "user", image: image, images: images, file: file, files: files)
     end
-    
+
     def assistant(message, response: nil, status: nil)
       add(message, role: "assistant", response: response, status: status)
     end
@@ -571,6 +571,8 @@ module AI
       end
     end
 
+    # :reek:DuplicateMethodCall
+    # :reek:TooManyStatements
     def wait_for_response(timeout)
         spinner = TTY::Spinner.new("[:spinner] Thinking ...", format: :dots)
         spinner.auto_spin


### PR DESCRIPTION
Resolves #4 

### Purpose

Add support for background API calls

### Solution

Proposed interface
```rb
chat.background = true
chat.generate! # => sets previous_response_id and returns
# { role: "assistant", content: nil, response_id: "foo", status: "queued" }
chat.get_response # => defaults to the chat's previous_response_id
# calls client.responses.retrieve("response_id_here") under the hood
# retrieves and appends response
# returns { role: "assistant", content: nil, response_id: "foo", status: "queued" } 
```

```rb
chat.get_response(wait: true) # => polls until ready
```

```rb
chat.previous_response_id = "foo"
chat.get_response # => # retrieves and appends response
chat.previous_response_id = "bar"
chat.get_response
chat.generate!
# could be used to combine outputs from different threads into one thread, or clear/compact conversations
```

---

#### Questions

- Should we have a timeout for background mode?
- Should an element of a `messages` have `nil` content? This was proposed, but OpenAI never returns `nil` and instead returns empty string.
- I added TTY Spinner. This is another dependency, maybe we don't want that.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds background mode for API calls with polling and timeout support, demonstrated in a new example, and introduces `tty-spinner` for visual feedback.
> 
>   - **Behavior**:
>     - Adds background mode for API calls in `lib/ai/chat.rb` with `background` attribute and `get_response(wait: true)` method.
>     - Introduces polling mechanism with timeout support using `wait_for_response()` and `timeout_request()`.
>     - Adds `tty-spinner` for visual feedback during polling.
>   - **Examples**:
>     - New example `14_background_mode.rb` demonstrates manual and automatic polling, and timeout handling.
>     - Updates `all.rb` to include the new example.
>   - **Dependencies**:
>     - Adds `tty-spinner` as a runtime dependency in `ai-chat.gemspec`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 1dabf0527d54905c9b90f6b41618eec7e9827a7a. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->