### PR TITLE
Re-enable code interpreter file generation

### DIFF
--- a/examples/13_code_interpreter.rb
+++ b/examples/13_code_interpreter.rb
@@ -32,3 +32,14 @@ b.user("Solve the equation 3x + 11 = 14.")
 puts b.generate![:content]
 puts "\n" * 5
 
+puts "Example 3: Basic file generation"
+puts "-" * 50
+
+c = AI::Chat.new
+c.code_interpreter = true
+
+c.user("Write an .csv file that contains a list of 10 random first names.")
+puts c.generate![:content]
+puts "Response contains generated file: #{!c.last.dig(:response, :images).empty? ? "✓ file is stored under :images key" : "✗ no file stored under :images key"}."
+puts "\n" * 5
+

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -232,7 +232,7 @@ module AI
     # :reek:TooManyStatements
     def parse_response(response)
       text_response = response.output_text
-      image_filenames = extract_and_save_images(response)
+      image_filenames = extract_and_save_images(response) + extract_and_save_files(response)
       response_id = response.id
       response_usage = response.usage.to_h.slice(:input_tokens, :output_tokens, :total_tokens)
 


### PR DESCRIPTION
Resolves #26 

This commit re-enables the retrieval of files generated by the code interpreter tool. Currently, the gem doesn't make the stores both "files" and "images" in the `image_folder` directory. We may want to change that in the future.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-enables file generation in `parse_response()` and updates example to demonstrate CSV file generation.
> 
>   - **Behavior**:
>     - Re-enables file generation in `parse_response()` in `chat.rb` by adding `extract_and_save_files()`.
>     - Updates `13_code_interpreter.rb` to include an example of generating a CSV file.
>   - **Misc**:
>     - Files are stored in the `image_folder` directory, which currently holds both images and files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 88f9d7c01d7f5c53b4e3637539565c7a6b5633ea. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->