### PR TITLE
Write JSON schemas to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ images/
 my_generated_images/
 examples/images/
 examples/my_generated_images/
+schema.json
+my_schemas/

--- a/README.md
+++ b/README.md
@@ -362,6 +362,40 @@ i.schema = '{"name":"nutrition_values","strict":true,"schema":{...}}'
 i.schema = '{"type":"object","properties":{...}}'
 ```
 
+### Generating a Schema
+
+You can call the class method `AI::Chat.generate_schema!` to use OpenAI to generate a JSON schema for you given a `String` describing the schema you want.
+
+```rb
+AI::Chat.generate_schema!("A user profile with name (required), email (required), age (number), and bio (optional text).")
+# => "{ ... }"
+```
+
+This method returns a String containing the JSON schema. The JSON schema also writes (or overwrites) to `schema.json` at the root of the project.
+
+Similar to generating messages with `AI::Chat` objects, this class method will assume that you have an API key called `OPENAI_API_KEY` defined. You can also pass the API key directly or choose a different environment variable key for it to use.
+
+```rb
+# Passing the API key directly
+AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", api_key: "MY_SECRET_API_KEY")
+
+# Choosing a different API key name
+AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", api_key_env_var: "CUSTOM_KEY")
+```
+
+You can choose a location for the schema to save by using the `location` keyword argument.
+
+```rb
+AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", location: "my_schemas/user.json")
+```
+
+If you don't want to write the output to a file, you can pass `false` to `location`.
+
+```rb
+AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", location: false)
+# => { ... }
+```
+
 ### Schema Notes
 
 - The keys can be `String`s or `Symbol`s.

--- a/examples/16_schema_generation.rb
+++ b/examples/16_schema_generation.rb
@@ -58,3 +58,45 @@ rescue => e
   puts "✗ Direct API key failed: #{e.message}"
 end
 puts
+
+puts "4. Schema Generation writes to schema.json by default"
+puts "-" * 60
+puts
+# Remove schema file if exists
+File.delete("schema.json") if File.exist?("schema.json")
+AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", api_key: ENV["OPENAI_API_KEY"])
+if File.exist?("schema.json")
+  puts "✓ AI::Chat.generate_schema! creates file"
+else
+  puts "✗ AI::Chat.generate_schema! fails to create file"
+end
+puts
+
+puts "5. Schema Generation DOES NOT write to file when location: false"
+puts "-" * 60
+puts
+# Remove schema file if exists
+File.delete("schema.json") if File.exist?("schema.json")
+puts AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", location: false, api_key: ENV["OPENAI_API_KEY"])
+puts
+if File.exist?("schema.json")
+  puts "✗ AI::Chat.generate_schema! creates file"
+else
+  puts "✓ AI::Chat.generate_schema! does not create file"
+end
+puts
+
+puts "6. Schema Generation writes to custom file given location"
+puts "-" * 60
+puts
+# Remove schema file if exists
+path = "my_schemas/test.json"
+File.delete(path) if File.exist?(path)
+puts AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", location: path, api_key: ENV["OPENAI_API_KEY"])
+puts
+if File.exist?(path)
+  puts "✓ AI::Chat.generate_schema! creates file at #{path}"
+else
+  puts "✗ AI::Chat.generate_schema! does not create file at #{path}"
+end
+puts

--- a/examples/16_schema_generation.rb
+++ b/examples/16_schema_generation.rb
@@ -100,3 +100,17 @@ else
   puts "✗ AI::Chat.generate_schema! does not create file at #{path}"
 end
 puts
+
+puts "7. AI::Chat can load the schema from a given file"
+puts "-" * 60
+puts
+puts AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required) default 'Smith'.")
+puts
+chat = AI::Chat.new
+chat.schema_file = "schema.json"
+if chat.schema.present?
+  puts "✓ AI::Chat#schema_file= assigns AI::Chat#schema"
+else
+  puts "✗ AI::Chat#schema_file= does not assign AI::Chat#schema"
+end
+puts

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -23,7 +23,7 @@ module AI
   class Chat
     # :reek:Attribute
     attr_accessor :background, :code_interpreter, :conversation_id, :image_generation, :image_folder, :messages, :model, :proxy, :previous_response_id, :web_search
-    attr_reader :reasoning_effort, :client, :schema
+    attr_reader :reasoning_effort, :client, :schema, :schema_file
 
     VALID_REASONING_EFFORTS = [:low, :medium, :high].freeze
     PROXY_URL = "https://prepend.me/".freeze
@@ -198,6 +198,12 @@ module AI
       else
         raise ArgumentError, "Invalid schema value: '#{value}'. Must be a String containing JSON or a Hash."
       end
+    end
+
+    def schema_file=(path)
+      @schema_file = path
+      content = File.open(path).read
+      self.schema = content
     end
 
     def last

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -40,7 +40,7 @@ module AI
       @image_folder = "./images"
     end
 
-    def self.generate_schema!(description, api_key: nil, api_key_env_var: "OPENAI_API_KEY", proxy: false)
+    def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: "OPENAI_API_KEY", proxy: false)
       api_key ||= ENV.fetch(api_key_env_var)
       prompt_path = File.expand_path("../prompts/schema_generator.md", __dir__)
       system_prompt = File.open(prompt_path).read
@@ -73,7 +73,15 @@ module AI
         output_text = response.output_text
         JSON.parse(output_text)
       end
-      JSON.pretty_generate(json)
+      content = JSON.pretty_generate(json)
+      if location
+        path = Pathname.new(location)
+        FileUtils.mkdir_p(path.dirname) if path.dirname != "."
+        File.open(location, "wb") do |file|
+          file.write(content)
+        end
+      end
+      content
     end
 
     # :reek:TooManyStatements

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -201,8 +201,8 @@ module AI
     end
 
     def schema_file=(path)
-      @schema_file = path
       content = File.open(path).read
+      @schema_file = path
       self.schema = content
     end
 

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -48,7 +48,7 @@ module AI
       json = if proxy
         uri = URI(PROXY_URL + "api.openai.com/v1/responses")
         parameters = {
-          model: "o4-mini",
+          model: "gpt-5.1",
           input: [
             {role: :system, content: system_prompt},
             {role: :user, content: description},


### PR DESCRIPTION
The current interface for schema generation feels a bit awkward.

- needing to `puts` the JSON string in the terminal and copy-pasting it
- needing to manually sanitize `'` from the JSON to avoid breaking the containing Ruby string

To address these issues, `AI::Chat.generate_schema!` now also writes the schema to a file.

```rb
# Writes to schema.json in the root directory of the project
AI::Chat.generate_schema!("...")

# Writes to custom file (creates folders if necessary)
AI::Chat.generate_schema!("...", location: "my_schemas/user.json")

# Only returns the generated String. Does not write to schema.json
AI::Chat.generate_schema!("...", location: false)
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `AI::Chat.generate_schema!` to write JSON schemas to files, with options for custom paths and disabling file output.
> 
>   - **Behavior**:
>     - `AI::Chat.generate_schema!` now writes JSON schema to `schema.json` by default.
>     - Supports custom file paths via `location` argument, creating directories if needed.
>     - Option to disable file writing by setting `location: false`.
>   - **Code Changes**:
>     - Updated `generate_schema!` in `chat.rb` to handle file writing logic.
>     - Added `schema_file=` method in `chat.rb` to load schema from a file.
>   - **Documentation**:
>     - Updated `README.md` with examples of new `generate_schema!` usage.
>     - Added tests in `examples/16_schema_generation.rb` to verify file writing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 06d0b83a3e696425bdabb710694e2d7c5a4ea6f6. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->