### PR TITLE
Add 'none' and 'minimal' reasoning efforts

### DIFF
--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -25,7 +25,7 @@ module AI
     attr_accessor :background, :code_interpreter, :conversation_id, :image_generation, :image_folder, :messages, :model, :proxy, :previous_response_id, :web_search
     attr_reader :reasoning_effort, :client, :schema, :schema_file
 
-    VALID_REASONING_EFFORTS = [:low, :medium, :high].freeze
+    VALID_REASONING_EFFORTS = [:none, :minimal, :low, :medium, :high].freeze
     PROXY_URL = "https://prepend.me/".freeze
 
     def initialize(api_key: nil, api_key_env_var: "OPENAI_API_KEY")


### PR DESCRIPTION
`gpt-5` supports `minimal` reasoning effort, and `gpt-5.1.` supports `none` (but not `minimal`).

I don't think we need to validate per model, because the API should return a good error message if an invalid reasoning effort is chosen, and we already pass those back (I think).