### PR TITLE
Remove reasoning_effort validation

### DIFF
--- a/examples/03_configuration.rb
+++ b/examples/03_configuration.rb
@@ -53,29 +53,4 @@ rescue => e
 end
 puts
 
-# Test 3: Reasoning effort configuration (for o-series models)
-puts "Test 3: Reasoning effort configuration"
-puts "-" * 30
-chat3 = AI::Chat.new
-chat3.model = "o1-mini"
-puts "Testing reasoning effort levels..."
-["low", "medium", "high", :low].each do |level|
-  chat3.reasoning_effort = level
-  puts "  Set reasoning_effort to #{level} (#{level.class}) - OK"
-rescue => e
-  puts "  Set reasoning_effort to #{level} - ERROR: #{e.message}"
-end
-
-# Test invalid value
-begin
-  chat3.reasoning_effort = "invalid"
-rescue ArgumentError => e
-  puts "  Invalid reasoning_effort correctly raises error: #{e.message}"
-end
-
-# Test nil value
-chat3.reasoning_effort = nil
-puts "  Set reasoning_effort to nil - OK"
-puts
-
 puts "=== Configuration tests completed ===="

--- a/examples/09_edge_cases.rb
+++ b/examples/09_edge_cases.rb
@@ -63,28 +63,24 @@ rescue => e
 end
 puts
 
-# Test 3: Reasoning effort validation
-puts "Test 3: Reasoning effort validation"
+# Test 3: Invalid reasoning effort - API error propagation
+puts "Test 3: Invalid reasoning effort - API error propagation"
 puts "-" * 50
 begin
   chat = AI::Chat.new
-  chat.model = "o1-mini"  # Reasoning model
-
-  # Valid values
-  [:low, :medium, :high, "low", "medium", "high", nil].each do |value|
-    chat.reasoning_effort = value
-    puts "✓ Reasoning effort '#{value.inspect}' (#{value.class}) accepted"
-  end
-
-  # Invalid values
-  ["extreme", :ultra, "invalid", 123].each do |value|
-    chat.reasoning_effort = value
-    puts "✗ Reasoning effort '#{value}' should have failed"
-  rescue ArgumentError => e
-    puts "✓ Invalid reasoning effort '#{value}' rejected: #{e.message[0..60]}..."
+  chat.model = "gpt-5.1"
+  chat.reasoning_effort = "minimal"
+  chat.user("Hello")
+  chat.generate!
+  puts "✗ Should have raised an error"
+rescue OpenAI::Errors::BadRequestError => e
+  if e.message.include?("minimal") && e.message.include?("Supported values")
+    puts "✓ API error correctly propagated with helpful message"
+  else
+    puts "✗ Error propagated but message unclear: #{e.message[0..80]}..."
   end
 rescue => e
-  puts "✗ Unexpected error: #{e.message}"
+  puts "✗ Unexpected error type: #{e.class} - #{e.message[0..80]}..."
 end
 puts
 

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -22,10 +22,9 @@ module AI
   # :reek:IrresponsibleModule
   class Chat
     # :reek:Attribute
-    attr_accessor :background, :code_interpreter, :conversation_id, :image_generation, :image_folder, :messages, :model, :proxy, :previous_response_id, :web_search
-    attr_reader :reasoning_effort, :client, :schema, :schema_file
+    attr_accessor :background, :code_interpreter, :conversation_id, :image_generation, :image_folder, :messages, :model, :proxy, :previous_response_id, :reasoning_effort, :web_search
+    attr_reader :client, :schema, :schema_file
 
-    VALID_REASONING_EFFORTS = [:low, :medium, :high].freeze
     PROXY_URL = "https://prepend.me/"
 
     def initialize(api_key: nil, api_key_env_var: "OPENAI_API_KEY")
@@ -167,24 +166,6 @@ module AI
         retrieve_response(previous_response_id)
       end
       parse_response(response)
-    end
-
-    # :reek:NilCheck
-    # :reek:TooManyStatements
-    def reasoning_effort=(value)
-      if value.nil?
-        @reasoning_effort = nil
-        return
-      end
-
-      normalized_value = value.to_sym
-
-      if VALID_REASONING_EFFORTS.include?(normalized_value)
-        @reasoning_effort = normalized_value
-      else
-        valid_values = VALID_REASONING_EFFORTS.map { |valid_value| ":#{valid_value} or \"#{valid_value}\"" }.join(", ")
-        raise ArgumentError, "Invalid reasoning_effort value: '#{value}'. Must be one of: #{valid_values}"
-      end
     end
 
     def schema=(value)

--- a/spec/integration/ai_chat_integration_spec.rb
+++ b/spec/integration/ai_chat_integration_spec.rb
@@ -179,22 +179,6 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
   end
 
-  describe "reasoning effort" do
-    it "accepts reasoning effort levels for o-series models" do
-      chat = AI::Chat.new
-      chat.model = "o1-mini"
-
-      expect { chat.reasoning_effort = "low" }.not_to raise_error
-      expect { chat.reasoning_effort = "medium" }.not_to raise_error
-      expect { chat.reasoning_effort = "high" }.not_to raise_error
-      expect { chat.reasoning_effort = :high }.not_to raise_error
-      expect { chat.reasoning_effort = :medium }.not_to raise_error
-      expect { chat.reasoning_effort = :low }.not_to raise_error
-
-      expect { chat.reasoning_effort = "invalid" }.to raise_error(ArgumentError)
-    end
-  end
-
   describe "image handling" do
     context "with a test image URL" do
       let(:test_image_url) { "https://picsum.photos/200/300" }


### PR DESCRIPTION
Makes the OpenAI API the source of truth for valid values. This makes the gem forward-compatible when OpenAI adds new reasoning effort options (like 'none' and 'minimal' for gpt-5.1).

Invalid values now propagate the API's error message directly to users.

Resolves #18
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes `reasoning_effort` validation in `AI::Chat`, deferring to OpenAI API for validation and error handling.
> 
>   - **Behavior**:
>     - Removes `reasoning_effort` validation in `AI::Chat` class, deferring to OpenAI API for validation.
>     - Invalid `reasoning_effort` values now propagate API error messages to users.
>   - **Examples**:
>     - Removes reasoning effort tests from `03_configuration.rb` and `09_edge_cases.rb`.
>   - **Tests**:
>     - Removes `reasoning effort` tests from `ai_chat_integration_spec.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 45828c13290a8b3613e4aeb4271eaf596103e2e4. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->