### PR TITLE
Expose last_response_id as public reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,25 @@ This information is useful for:
 - Understanding which model was actually used.
 - Future features like cost tracking.
 
+### Last Response ID
+
+In addition to the `response` object inside each message, the `AI::Chat` instance also provides a convenient reader, `last_response_id`, which always holds the ID of the most recent response.
+
+```ruby
+chat = AI::Chat.new
+chat.user("Hello")
+chat.generate!
+
+puts chat.last_response_id # => "resp_abc123..."
+
+chat.user("Goodbye")
+chat.generate!
+
+puts chat.last_response_id # => "resp_xyz789..." (a new ID)
+```
+
+This is particularly useful for managing background tasks. When you make a request in background mode, you can immediately get the `last_response_id` to track, retrieve, or cancel that specific job later from a different process.
+
 ### Automatic Conversation Management
 
 Starting with your first `generate!` call, the gem automatically creates and manages a conversation with OpenAI. This conversation is stored server-side and tracks all messages, tool calls, reasoning, and other items.

--- a/examples/01_quick.rb
+++ b/examples/01_quick.rb
@@ -58,6 +58,9 @@ chat4 = AI::Chat.new
 chat4.user("My name is Alice and I like Ruby programming")
 chat4.generate!
 conv_id = chat4.conversation_id
+resp_id = chat4.last_response_id
+puts "   Conversation ID: #{conv_id}"
+puts "   Last Response ID: #{resp_id}"
 
 # New chat instance with memory
 chat5 = AI::Chat.new

--- a/examples/02_core.rb
+++ b/examples/02_core.rb
@@ -18,14 +18,31 @@ puts "✓ Message: #{message}"
 puts "✓ Response contains answer: #{chat1.last[:content].match?(/4|four/i)}"
 puts
 
-# Test 2: Response details
-puts "Test 2: Response details"
+# Test 2: Conversation and Response IDs
+puts "Test 2: Conversation and Response IDs"
 puts "-" * 30
-chat5 = AI::Chat.new
-chat5.user("Say hello")
-chat5.generate!
-response_obj = chat5.last[:response]
-puts "✓ Response ID: #{response_obj[:id]}"
+chat2 = AI::Chat.new
+chat2.user("My name is Bob.")
+chat2.generate!
+puts "✓ Conversation ID created: #{chat2.conversation_id}"
+puts "✓ Last Response ID created: #{chat2.last_response_id}"
+first_resp_id = chat2.last_response_id
+
+chat2.user("What is my name?")
+chat2.generate!
+puts "✓ Conversation ID is maintained: #{chat2.conversation_id}"
+puts "✓ Last Response ID is updated: #{chat2.last_response_id}"
+puts "✓ New response ID is different: #{chat2.last_response_id != first_resp_id}"
+puts
+
+# Test 3: Response details
+puts "Test 3: Response details"
+puts "-" * 30
+chat3 = AI::Chat.new
+chat3.user("Say hello")
+chat3.generate!
+response_obj = chat3.last[:response]
+puts "✓ Response ID from message: #{response_obj[:id]}"
 puts "✓ Model: #{response_obj[:model]}"
 puts "✓ Usage: #{response_obj[:usage]}"
 puts "✓ Total tokens: #{response_obj[:total_tokens]}"

--- a/spec/integration/ai_chat_integration_spec.rb
+++ b/spec/integration/ai_chat_integration_spec.rb
@@ -252,6 +252,25 @@ RSpec.describe "AI::Chat Integration", :integration do
       expect(response_obj[:usage][:total_tokens]).to be_a(Integer)
       expect(response_obj[:total_tokens]).to eq(response_obj[:usage][:total_tokens])
     end
+
+    it "updates last_response_id after each generate!" do
+      chat = AI::Chat.new
+
+      expect(chat.last_response_id).to be_nil
+
+      chat.user("Hello")
+      chat.generate!
+
+      first_id = chat.last_response_id
+      expect(first_id).to match(/^resp_/)
+
+      chat.user("Goodbye")
+      chat.generate!
+
+      second_id = chat.last_response_id
+      expect(second_id).to match(/^resp_/)
+      expect(second_id).not_to eq(first_id)
+    end
   end
 
   describe "messages manipulation" do


### PR DESCRIPTION
Useful for background mode workflows where you need to track, retrieve, or cancel a specific response from another process. Internal reads now use the accessor method for idiomatic Ruby.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose `last_response_id` as a public reader in `AI::Chat` for tracking responses, with internal reads using the accessor method.
> 
>   - **Behavior**:
>     - Exposes `last_response_id` as a public reader in `AI::Chat` for tracking responses in background workflows.
>     - Internal reads now use the `last_response_id` accessor method for idiomatic Ruby.
>   - **Examples**:
>     - Updates `01_quick.rb` and `02_core.rb` to demonstrate `last_response_id` usage.
>   - **Tests**:
>     - Adds test in `ai_chat_integration_spec.rb` to verify `last_response_id` updates after each `generate!` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fai-chat&utm_source=github&utm_medium=referral)<sup> for 3144fcab96a282a488a33da0cc0dccd645fabd26. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->