### PR TITLE
Update API validation messages

### DIFF
--- a/examples/15_proxy.rb
+++ b/examples/15_proxy.rb
@@ -11,6 +11,14 @@ require "amazing_print"
 puts "\n=== AI::Chat Proxy Examples ==="
 puts
 
+puts "0. Validate API key:"
+chat = AI::Chat.new(api_key_env_var: "PROXY_API_KEY")
+chat.proxy = true
+chat.user("What's the capital of Florida?")
+chat.generate![:content]
+puts "   API Key validated: #{chat.instance_variable_get(:@api_key_validated)}"
+puts
+
 puts "1. Basic conversation:"
 chat = AI::Chat.new(api_key_env_var: "PROXY_API_KEY")
 chat.proxy = true


### PR DESCRIPTION
Resolves #48 

The [recommended way](https://community.openai.com/t/what-are-the-valid-characters-for-the-apikey/288643) to validate an API token appears to be making an API call and checking if there's an authentication error.
This API call does not cost money to hit, so it should be fine to use.

I've removed mention of prepend.me from the validation error when proxying is disabled, since it could be confusing if prepend.me hasn't been mentioned.

I'm only validating the token once, since there's no public method to update the token after initialization.