### PR TITLE
Support verbosity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.5.1)
+    ai-chat (0.5.4)
       amazing_print (~> 2.0)
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -671,6 +671,15 @@ The `reasoning_effort` parameter guides the model on how many reasoning tokens t
 
 By default, `reasoning_effort` is `nil`, which means no reasoning parameter is sent to the API. For `gpt-5.2` (the default model), this is equivalent to `"none"` reasoning.
 
+## Verbosity
+
+Verbosity determines how many output tokens are generated. Lowering the number of tokens reduces overall latency. While the model's reasoning approach stays mostly the same, the model finds ways to answer more concisely—which can either improve or diminish answer quality, depending on your use case. Here are some scenarios for both ends of the verbosity spectrum:
+
+- High verbosity: Use when you need the model to provide thorough explanations of documents or perform extensive code refactoring.
+- Low verbosity: Best for situations where you want concise answers or simple code generation, such as SQL queries.
+
+The supported values are `:high`, `:medium`, or `:low`. The default value is `:medium` for `gpt-5.2`. **Older models (like `gpt-4.1-nano`) only support `:medium`**.
+
 ## Advanced: Response Details
 
 When you call `generate!` (or later call `get_response` in background mode), the gem stores additional information about the API response:

--- a/examples/17_verbosity.rb
+++ b/examples/17_verbosity.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/ai-chat"
+require "dotenv"
+Dotenv.load(File.expand_path("../.env", __dir__))
+require "amazing_print"
+
+puts "\n=== AI::Chat Verbosity Tests ==="
+puts
+
+puts "1. Supports verbosity = :low"
+puts "-" * 30
+chat1 = AI::Chat.new
+chat1.verbosity = :low
+chat1.user("How high do planes typically fly?")
+response = chat1.generate![:content]
+puts response
+puts
+puts "Total characters: #{response.length}"
+puts
+
+puts "2. Supports verbosity = :medium"
+puts "-" * 30
+chat2 = AI::Chat.new
+chat2.verbosity = :medium
+chat2.user("How high do planes typically fly?")
+response = chat2.generate![:content]
+puts response
+puts
+puts "Total characters: #{response.length}"
+puts
+
+puts "3. Supports verbosity = :high"
+puts "-" * 30
+chat3 = AI::Chat.new
+chat3.verbosity = :medium
+chat3.user("How high do planes typically fly?")
+response = chat3.generate![:content]
+puts response
+puts
+puts "Total characters: #{response.length}"
+puts
+
+puts "4. Raises error for unsupported verbosity values"
+puts "-" * 30
+chat4 = AI::Chat.new
+chat4.user("How high do planes typically fly?")
+  begin
+    chat4.verbosity = :extreme
+  puts "✗ Failed to raise ArgumentError for invalid verbosity: #{chat4.verbosity}"
+rescue ArgumentError => e
+  puts "✓ Raises Argument error correctly: #{e.message}"
+end
+puts
+
+puts
+puts "5. Supports verbosity with Structured Outputs"
+puts "-" * 30
+path = "my_schemas/test.json"
+File.delete(path) if File.exist?(path)
+AI::Chat.generate_schema!("A user with full name (required), first_name (required), last_name (required), coolness_level (score between 0-10 representing how cool the user sounds), coolness_reasoning (the explanation of the coolness_leve)", location: path, api_key: ENV["OPENAI_API_KEY"])
+
+chat5 = AI::Chat.new
+chat5.verbosity = :low
+chat5.schema_file = path
+chat5.system("Extract the profile information from the user message. Describe it like a 90's robot.")
+chat5.user("My name is Bryan. I like to skateboard and be cool. I'm seventeen and a quarter. You can reach me at bryan@example.com.")
+puts chat5.last[:content]
+puts 
+begin
+  response = chat5.generate![:content]
+  puts "✓ Generates structured output response with verbosity"
+rescue => e
+  puts "✗ Failed to generate structured output response with verbosity: #{e.message}"
+end
+puts
+
+puts "6. Supports verbosity = :medium for gpt-4.1-nano"
+puts "-" * 30
+chat6 = AI::Chat.new
+chat6.model = "gpt-4.1-nano"
+chat6.verbosity = :medium
+chat6.user("How high do planes typically fly?")
+response = chat6.generate![:content]
+puts response
+puts
+puts "Total characters: #{response.length}"
+puts
+
+puts "7. Fails verbosity = :low for gpt-4.1-nano"
+puts "-" * 30
+chat7 = AI::Chat.new
+chat7.model = "gpt-4.1-nano"
+chat7.verbosity = :low
+chat7.user("How high do planes typically fly?")
+begin
+  response = chat7.generate![:content]
+  puts "✗ Failed to raise error when setting :low verbosity on unsupported model."
+rescue OpenAI::Errors::BadRequestError => e
+  puts "✓ Successfully raises error on for unsupported verbosity for older model: #{e.message}"
+end
+puts

--- a/examples/all.rb
+++ b/examples/all.rb
@@ -53,3 +53,9 @@ require_relative "14_schema_generation"
 
 # Proxy
 require_relative "15_proxy"
+
+# Get items
+require_relative "16_get_items"
+
+# Verbosity
+require_relative "17_verbosity"

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -34,7 +34,7 @@ module AI
       @image_generation = false
       @image_folder = "./images"
       @api_key_validated = false
-      @verbosity = "medium"
+      @verbosity = :medium
     end
 
     def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: "OPENAI_API_KEY", proxy: false)


### PR DESCRIPTION
Resolves #17 

This commit adds support for verbosity control.

```rb
chat = AI::Chat.new
chat.verbosity = :high
...
```

Valid values for `verbosity` are `:low`, `:medium`, `:high`. The String versions will also be accepted and will be saved as Symbols. The default value is `:medium`, which is supported by older models like `gpt-4.1-nano`. Older models do not support values other than `"medium"`.