### PR TITLE
Default proxy mode from AICHAT_PROXY env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2026-03-02
+
+### Changed
+
+- **Proxy default from env**: `AI::Chat.new` now enables proxy mode by default when `AICHAT_PROXY` is exactly `"true"`.
+
+- **Schema generation proxy default**: `AI::Chat.generate_schema!` now uses the same `AICHAT_PROXY` default when `proxy:` is omitted.
+
+- **Explicit override precedence**: Explicit `chat.proxy = ...` and `generate_schema!(..., proxy: ...)` continue to override env defaults.
+
+### Added
+
+- **Unit coverage for proxy defaults**: Added tests for env parsing (`"true"` exact match), explicit override behavior, and `generate_schema!` precedence.
+
+- **Proxy env documentation**: README now documents `AICHAT_PROXY` behavior for both chat generation and schema generation.
+
 ## [0.5.5] - 2026-02-10
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.5.5)
+    ai-chat (0.5.6)
       amazing_print (~> 2.0)
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -414,6 +414,14 @@ AI::Chat.generate_schema!("A user with full name (required), first_name (require
 AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", api_key_env_var: "CUSTOM_KEY")
 ```
 
+`generate_schema!` also follows proxy defaults from the `AICHAT_PROXY` environment variable. Proxy is enabled only when `AICHAT_PROXY` is exactly `"true"`.
+
+```bash
+export AICHAT_PROXY=true
+```
+
+If you pass `proxy: true` or `proxy: false`, that explicit value overrides the env default.
+
 You can choose a location for the schema to save by using the `location` keyword argument.
 
 ```rb
@@ -621,6 +629,14 @@ chat.generate!
 puts chat.last[:content]
 # => "Once upon a time..."
 ```
+
+You can also default proxy mode from the environment for both `AI::Chat.new` and `AI::Chat.generate_schema!`:
+
+```bash
+export AICHAT_PROXY=true
+```
+
+Proxy is enabled only when `AICHAT_PROXY` is exactly `"true"`. Any other value (including `"TRUE"` or `"1"`) leaves proxy disabled unless you explicitly set `chat.proxy = true` or pass `proxy: true`.
 
 When proxy is enabled, **you must use the API key provided by prepend.me** in place of a real OpenAI API key. Refer to [the section on API keys](#api-key) for options on how to set your key.
 

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ai-chat"
-  spec.version = "0.5.5"
+  spec.version = "0.5.6"
   spec.authors = ["Raghu Betina", "Jelani Woods"]
   spec.email = ["raghu@firstdraft.com", "jelani@firstdraft.com"]
   spec.homepage = "https://github.com/firstdraft/ai-chat"

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -25,11 +25,13 @@ module AI
 
     def initialize(api_key: nil, api_key_env_var: "OPENAI_API_KEY")
       @api_key = api_key || ENV.fetch(api_key_env_var)
-      @proxy = false
+      @proxy = ENV["AICHAT_PROXY"] == "true"
       @messages = []
       @reasoning_effort = nil
       @model = "gpt-5.2"
-      @client = OpenAI::Client.new(api_key: @api_key)
+      client_options = {api_key: @api_key}
+      client_options[:base_url] = BASE_PROXY_URL if @proxy
+      @client = OpenAI::Client.new(**client_options)
       @last_response_id = nil
       @image_generation = false
       @image_folder = "./images"
@@ -37,8 +39,9 @@ module AI
       @verbosity = :medium
     end
 
-    def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: "OPENAI_API_KEY", proxy: false)
+    def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: "OPENAI_API_KEY", proxy: nil)
       api_key ||= ENV.fetch(api_key_env_var)
+      proxy = ENV["AICHAT_PROXY"] == "true" if proxy.nil?
       prompt_path = File.expand_path("../prompts/schema_generator.md", __dir__)
       system_prompt = File.read(prompt_path)
 


### PR DESCRIPTION
Enable proxy by default when AICHAT_PROXY is exactly "true".

This applies to both AI::Chat.new and AI::Chat.generate_schema!
when proxy: is omitted. Explicit settings still take precedence:
`chat.proxy=` and `generate_schema!(proxy: ...)` override env defaults.

Add unit tests for env parsing, constructor client wiring, and
generate_schema! precedence behavior. Add README docs for env
usage and precedence semantics.

Bump version to 0.5.6 and add changelog entry for the release.