### PR TITLE
Prefer AICHAT_API_KEY in default lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2026-03-02
+
+### Changed
+
+- **Default API key lookup order**: `AI::Chat.new` and `AI::Chat.generate_schema!` now look for `AICHAT_API_KEY` first, then fall back to `OPENAI_API_KEY` when the first value is missing or empty.
+
+- **Explicit API key override behavior**: Passing `api_key:` still takes highest precedence, and passing `api_key_env_var:` still uses that environment variable exactly.
+
+### Added
+
+- **Unit coverage for API key precedence**: Added tests covering default env order, empty `AICHAT_API_KEY` fallback, explicit `api_key_env_var:`, and explicit `api_key:` behavior.
+
+### Updated
+
+- **Integration test setup**: Integration tests now run when either `AICHAT_API_KEY` or `OPENAI_API_KEY` is present.
+
+- **Documentation**: README now documents the new default key lookup order and updates the direct `OpenAI::Client` example to match.
+
 ## [0.5.6] - 2026-03-02
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.5.6)
+    ai-chat (0.5.7)
       amazing_print (~> 2.0)
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ See [OpenAI's model documentation](https://platform.openai.com/docs/models) for 
 
 ### API key
 
-The gem by default looks for an environment variable called `OPENAI_API_KEY` and uses that if it finds it.
+The gem by default looks for `AICHAT_API_KEY` first. If that is missing (or empty), it falls back to `OPENAI_API_KEY`.
 
 You can specify a different environment variable name:
 
@@ -404,7 +404,7 @@ AI::Chat.generate_schema!("A user profile with name (required), email (required)
 
 This method returns a String containing the JSON schema. The JSON schema also writes (or overwrites) to `schema.json` at the root of the project.
 
-Similar to generating messages with `AI::Chat` objects, this class method will assume that you have an API key called `OPENAI_API_KEY` defined. You can also pass the API key directly or choose a different environment variable key for it to use.
+Similar to generating messages with `AI::Chat` objects, this class method will look for `AICHAT_API_KEY` first, then fall back to `OPENAI_API_KEY` if needed. You can also pass the API key directly or choose a different environment variable key for it to use.
 
 ```rb
 # Passing the API key directly
@@ -748,7 +748,9 @@ This is particularly useful for background mode workflows. If you want to retrie
 ```ruby
 require "openai"
 
-client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
+api_key = ENV["AICHAT_API_KEY"]
+api_key = ENV.fetch("OPENAI_API_KEY") if api_key.nil? || api_key.empty?
+client = OpenAI::Client.new(api_key: api_key)
 
 response_id = "resp_abc123..." # e.g., load from your database
 response = client.responses.retrieve(response_id)

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ai-chat"
-  spec.version = "0.5.6"
+  spec.version = "0.5.7"
   spec.authors = ["Raghu Betina", "Jelani Woods"]
   spec.email = ["raghu@firstdraft.com", "jelani@firstdraft.com"]
   spec.homepage = "https://github.com/firstdraft/ai-chat"

--- a/spec/integration/ai_chat_integration_spec.rb
+++ b/spec/integration/ai_chat_integration_spec.rb
@@ -225,12 +225,12 @@ RSpec.describe "AI::Chat Integration", :integration do
   end
 
   describe "API key configuration" do
-    it "uses OPENAI_API_KEY environment variable by default" do
+    it "uses the default API key env lookup by default" do
       expect { AI::Chat.new }.not_to raise_error
     end
 
     it "accepts a custom environment variable name" do
-      ENV["CUSTOM_OPENAI_KEY"] = ENV["OPENAI_API_KEY"]
+      ENV["CUSTOM_OPENAI_KEY"] = ENV["AICHAT_API_KEY"] || ENV["OPENAI_API_KEY"]
 
       chat = AI::Chat.new(api_key_env_var: "CUSTOM_OPENAI_KEY")
       chat.user("Hi")
@@ -241,7 +241,7 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts an API key directly" do
-      chat = AI::Chat.new(api_key: ENV["OPENAI_API_KEY"])
+      chat = AI::Chat.new(api_key: ENV["AICHAT_API_KEY"] || ENV["OPENAI_API_KEY"])
       chat.user("Hi")
 
       expect { chat.generate! }.not_to raise_error

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -2,8 +2,8 @@
 
 RSpec.configure do |config|
   config.before(:each, :integration) do
-    if ENV["OPENAI_API_KEY"].nil?
-      skip "Integration tests require OPENAI_API_KEY environment variable"
+    if ENV["AICHAT_API_KEY"].to_s.empty? && ENV["OPENAI_API_KEY"].to_s.empty?
+      skip "Integration tests require AICHAT_API_KEY or OPENAI_API_KEY environment variable"
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR updates default API key lookup to prefer `AICHAT_API_KEY` while
preserving backward compatibility with `OPENAI_API_KEY`.

## What Changed

- Updated `AI::Chat.new` and `AI::Chat.generate_schema!` default key
  resolution:
  - first tries `AICHAT_API_KEY`
  - falls back to `OPENAI_API_KEY` when `AICHAT_API_KEY` is missing or
    empty
- Preserved explicit override semantics:
  - `api_key:` still has highest precedence
  - `api_key_env_var:` still uses that exact environment variable
- Added/updated tests for:
  - default env var precedence
  - empty `AICHAT_API_KEY` fallback
  - explicit `api_key_env_var:` behavior
  - explicit `api_key:` behavior
- Updated integration skip logic so integration tests run when either
  `AICHAT_API_KEY` or `OPENAI_API_KEY` is set
- Updated README API key docs and direct `OpenAI::Client` example to match
  runtime behavior
- Bumped gem version from `0.5.6` to `0.5.7`
- Added changelog entry for `0.5.7`

## Compatibility

- Existing setups using only `OPENAI_API_KEY` continue to work unchanged.
- Projects can now use a gem-scoped key via `AICHAT_API_KEY` without
  changing app-wide key names.

## Verification

- `bundle exec standardrb lib/ai/chat.rb spec/unit/chat_spec.rb spec/integration/ai_chat_integration_spec.rb spec/support/integration_helper.rb`
- `bundle exec rspec spec/unit/chat_spec.rb`
- `bundle exec rspec spec/integration/ai_chat_integration_spec.rb:227`

All commands passed.
