### PR TITLE
Fix empty AICHAT_API_KEY fallback in integration specs

### DIFF
--- a/spec/integration/ai_chat_integration_spec.rb
+++ b/spec/integration/ai_chat_integration_spec.rb
@@ -230,7 +230,9 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts a custom environment variable name" do
-      ENV["CUSTOM_OPENAI_KEY"] = ENV["AICHAT_API_KEY"] || ENV["OPENAI_API_KEY"]
+      preferred_key = ENV["AICHAT_API_KEY"]
+      preferred_key = ENV["OPENAI_API_KEY"] if preferred_key.to_s.empty?
+      ENV["CUSTOM_OPENAI_KEY"] = preferred_key
 
       chat = AI::Chat.new(api_key_env_var: "CUSTOM_OPENAI_KEY")
       chat.user("Hi")
@@ -241,7 +243,9 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts an API key directly" do
-      chat = AI::Chat.new(api_key: ENV["AICHAT_API_KEY"] || ENV["OPENAI_API_KEY"])
+      api_key = ENV["AICHAT_API_KEY"]
+      api_key = ENV["OPENAI_API_KEY"] if api_key.to_s.empty?
+      chat = AI::Chat.new(api_key: api_key)
       chat.user("Hi")
 
       expect { chat.generate! }.not_to raise_error


### PR DESCRIPTION
## Summary

Fixes a bug in the integration test setup introduced in PR #56.

The previous test setup used:

- `ENV["AICHAT_API_KEY"] || ENV["OPENAI_API_KEY"]`

In Ruby, an empty string is truthy, so when `AICHAT_API_KEY=""`, tests
would incorrectly use the empty key instead of falling back.

## What changed

- Updated `spec/integration/ai_chat_integration_spec.rb` API key setup to
  treat empty `AICHAT_API_KEY` as missing before fallback.
- Applied this in both places:
  - custom env-var test setup (`CUSTOM_OPENAI_KEY` assignment)
  - direct `api_key:` test setup

## Why

This aligns integration test setup with runtime behavior, where empty
`AICHAT_API_KEY` should fall back to `OPENAI_API_KEY`.

## Verification

- `bundle exec standardrb spec/integration/ai_chat_integration_spec.rb`
- `bundle exec rspec spec/integration/ai_chat_integration_spec.rb:227`

Both passed locally.
