### PR TITLE
Overhaul proxy config and API key resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-13
+
+### Breaking
+
+- **Proxy-aware API key resolution**: The gem no longer falls back from `AICHAT_PROXY_KEY` to `OPENAI_API_KEY`. When proxy is off, it uses `OPENAI_API_KEY`. When proxy is on (`AICHAT_PROXY=true`), it uses `AICHAT_PROXY_KEY`. Missing the expected var raises a `KeyError` with guidance on which variable to create.
+
+### Added
+
+- **`proxy:` keyword argument on `initialize`**: Override the `AICHAT_PROXY` env default at construction time, e.g. `AI::Chat.new(proxy: true)`.
+
+- **Case-insensitive `AICHAT_PROXY`**: `TRUE`, `True`, etc. are now accepted.
+
+- **Transactional `proxy=` setter**: Toggling proxy re-resolves the API key and resets validation. If key resolution fails, the instance is rolled back to its previous state.
+
+- **Beginner-friendly error messages**: Missing env var and auth failure errors now name the specific variable and where to get a key.
+
+### Changed
+
+- **Boolean coercion for proxy values**: `proxy:` kwarg and `proxy=` setter coerce values with `!!`. Only `nil` defers to the env var.
+
+- **Env var names extracted to constants**: `PROXY_ENV`, `PROXY_KEY_ENV`, `OPENAI_KEY_ENV` defined once on the class.
+
 ## [0.5.8] - 2026-03-02
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.5.8)
+    ai-chat (0.6.0)
       amazing_print (~> 2.0)
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ See [OpenAI's model documentation](https://platform.openai.com/docs/models) for 
 
 ### API key
 
-The gem by default looks for `AICHAT_PROXY_KEY` first. If that is missing (or empty), it falls back to `OPENAI_API_KEY`.
+By default, the gem uses `OPENAI_API_KEY`. When proxy mode is enabled (`AICHAT_PROXY=true`), it uses `AICHAT_PROXY_KEY` instead.
 
 You can specify a different environment variable name:
 
@@ -404,7 +404,7 @@ AI::Chat.generate_schema!("A user profile with name (required), email (required)
 
 This method returns a String containing the JSON schema. The JSON schema also writes (or overwrites) to `schema.json` at the root of the project.
 
-Similar to generating messages with `AI::Chat` objects, this class method will look for `AICHAT_PROXY_KEY` first, then fall back to `OPENAI_API_KEY` if needed. You can also pass the API key directly or choose a different environment variable key for it to use.
+This class method uses the same API key and proxy resolution as `AI::Chat.new`. You can also pass the API key directly or choose a different environment variable:
 
 ```rb
 # Passing the API key directly
@@ -748,9 +748,7 @@ This is particularly useful for background mode workflows. If you want to retrie
 ```ruby
 require "openai"
 
-api_key = ENV["AICHAT_PROXY_KEY"]
-api_key = ENV.fetch("OPENAI_API_KEY") if api_key.nil? || api_key.empty?
-client = OpenAI::Client.new(api_key: api_key)
+client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
 
 response_id = "resp_abc123..." # e.g., load from your database
 response = client.responses.retrieve(response_id)

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ AI::Chat.generate_schema!("A user with full name (required), first_name (require
 AI::Chat.generate_schema!("A user with full name (required), first_name (required), and last_name (required).", api_key_env_var: "CUSTOM_KEY")
 ```
 
-`generate_schema!` also follows proxy defaults from the `AICHAT_PROXY` environment variable. Proxy is enabled only when `AICHAT_PROXY` is exactly `"true"`.
+`generate_schema!` also follows proxy defaults from the `AICHAT_PROXY` environment variable.
 
 ```bash
 export AICHAT_PROXY=true
@@ -617,28 +617,30 @@ message = chat.get_response(wait: true, timeout: 600)
 puts message[:content]
 ```
 
-## Proxying Through prepend.me
+## Proxying Through Prepend.me
 
-You can proxy API calls through [prepend.me](https://prepend.me/).
+You can proxy API calls through [Prepend.me](https://prepend.me/). When proxy mode is enabled, the gem uses the `AICHAT_PROXY_KEY` environment variable instead of `OPENAI_API_KEY`.
+
+You can enable proxy mode at construction time:
 
 ```rb
-chat = AI::Chat.new
-chat.proxy = true
-chat.user("Tell me a story")
-chat.generate!
-puts chat.last[:content]
-# => "Once upon a time..."
+chat = AI::Chat.new(proxy: true)
 ```
 
-You can also default proxy mode from the environment for both `AI::Chat.new` and `AI::Chat.generate_schema!`:
+Or default it from the environment (case-insensitive):
 
 ```bash
 export AICHAT_PROXY=true
 ```
 
-Proxy is enabled only when `AICHAT_PROXY` is exactly `"true"`. Any other value (including `"TRUE"` or `"1"`) leaves proxy disabled unless you explicitly set `chat.proxy = true` or pass `proxy: true`.
+Or toggle it on an existing instance:
 
-When proxy is enabled, **you must use the API key provided by prepend.me** in place of a real OpenAI API key. Refer to [the section on API keys](#api-key) for options on how to set your key.
+```rb
+chat = AI::Chat.new
+chat.proxy = true
+```
+
+When proxy is enabled, **you must set `AICHAT_PROXY_KEY`** with your API key from Prepend.me.
 
 ## Building Conversations Without API Calls
 

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ai-chat"
-  spec.version = "0.5.8"
+  spec.version = "0.6.0"
   spec.authors = ["Raghu Betina", "Jelani Woods"]
   spec.email = ["raghu@firstdraft.com", "jelani@firstdraft.com"]
   spec.homepage = "https://github.com/firstdraft/ai-chat"

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -166,6 +166,7 @@ module AI
     def proxy=(value)
       @proxy = !!value
       @api_key = resolve_api_key
+      @api_key_validated = false
       client_options = {api_key: @api_key}
       client_options[:base_url] = BASE_PROXY_URL if @proxy
       @client = OpenAI::Client.new(**client_options)

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -22,10 +22,15 @@ module AI
     attr_reader :client, :last_response_id, :proxy, :schema, :schema_file, :verbosity
 
     BASE_PROXY_URL = "https://prepend.me/api.openai.com/v1"
+    PROXY_ENV = "AICHAT_PROXY"
+    PROXY_KEY_ENV = "AICHAT_PROXY_KEY"
+    OPENAI_KEY_ENV = "OPENAI_API_KEY"
 
     def initialize(api_key: nil, api_key_env_var: nil, proxy: nil)
-      @proxy = proxy.nil? ? ENV["AICHAT_PROXY"]&.downcase == "true" : !!proxy
-      @api_key = api_key || ENV.fetch(api_key_env_var || (@proxy ? "AICHAT_PROXY_KEY" : "OPENAI_API_KEY"))
+      @api_key_arg = api_key
+      @api_key_env_var_arg = api_key_env_var
+      @proxy = proxy.nil? ? ENV[PROXY_ENV]&.downcase == "true" : !!proxy
+      @api_key = resolve_api_key
       @messages = []
       @reasoning_effort = nil
       @model = "gpt-5.2"
@@ -40,12 +45,8 @@ module AI
     end
 
     def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: nil, proxy: nil)
-      proxy = if proxy.nil?
-        ENV["AICHAT_PROXY"]&.downcase == "true"
-      else
-        !!proxy
-      end
-      api_key = api_key || ENV.fetch(api_key_env_var || (proxy ? "AICHAT_PROXY_KEY" : "OPENAI_API_KEY"))
+      proxy = proxy.nil? ? ENV[PROXY_ENV]&.downcase == "true" : !!proxy
+      api_key = api_key || ENV.fetch(api_key_env_var || (proxy ? PROXY_KEY_ENV : OPENAI_KEY_ENV))
       prompt_path = File.expand_path("../prompts/schema_generator.md", __dir__)
       system_prompt = File.read(prompt_path)
 
@@ -164,14 +165,10 @@ module AI
 
     def proxy=(value)
       @proxy = !!value
-      @client = if value
-        OpenAI::Client.new(
-          api_key: @api_key,
-          base_url: BASE_PROXY_URL
-        )
-      else
-        OpenAI::Client.new(api_key: @api_key)
-      end
+      @api_key = resolve_api_key
+      client_options = {api_key: @api_key}
+      client_options[:base_url] = BASE_PROXY_URL if @proxy
+      @client = OpenAI::Client.new(**client_options)
     end
 
     def schema=(value)
@@ -255,6 +252,10 @@ module AI
     end
 
     private
+
+    def resolve_api_key
+      @api_key_arg || ENV.fetch(@api_key_env_var_arg || (@proxy ? PROXY_KEY_ENV : OPENAI_KEY_ENV))
+    end
 
     class InputClassificationError < StandardError; end
 

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -23,9 +23,9 @@ module AI
 
     BASE_PROXY_URL = "https://prepend.me/api.openai.com/v1"
 
-    def initialize(api_key: nil, api_key_env_var: nil)
+    def initialize(api_key: nil, api_key_env_var: nil, proxy: nil)
       @api_key = self.class.resolve_api_key(api_key: api_key, api_key_env_var: api_key_env_var)
-      @proxy = ENV["AICHAT_PROXY"] == "true"
+      @proxy = proxy.nil? ? ENV["AICHAT_PROXY"]&.downcase == "true" : !!proxy
       @messages = []
       @reasoning_effort = nil
       @model = "gpt-5.2"
@@ -41,7 +41,11 @@ module AI
 
     def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: nil, proxy: nil)
       api_key = resolve_api_key(api_key: api_key, api_key_env_var: api_key_env_var)
-      proxy = ENV["AICHAT_PROXY"] == "true" if proxy.nil?
+      proxy = if proxy.nil?
+        ENV["AICHAT_PROXY"]&.downcase == "true"
+      else
+        !!proxy
+      end
       prompt_path = File.expand_path("../prompts/schema_generator.md", __dir__)
       system_prompt = File.read(prompt_path)
 
@@ -169,7 +173,7 @@ module AI
     end
 
     def proxy=(value)
-      @proxy = value
+      @proxy = !!value
       @client = if value
         OpenAI::Client.new(
           api_key: @api_key,

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -24,8 +24,8 @@ module AI
     BASE_PROXY_URL = "https://prepend.me/api.openai.com/v1"
 
     def initialize(api_key: nil, api_key_env_var: nil, proxy: nil)
-      @api_key = self.class.resolve_api_key(api_key: api_key, api_key_env_var: api_key_env_var)
       @proxy = proxy.nil? ? ENV["AICHAT_PROXY"]&.downcase == "true" : !!proxy
+      @api_key = api_key || ENV.fetch(api_key_env_var || (@proxy ? "AICHAT_PROXY_KEY" : "OPENAI_API_KEY"))
       @messages = []
       @reasoning_effort = nil
       @model = "gpt-5.2"
@@ -40,12 +40,12 @@ module AI
     end
 
     def self.generate_schema!(description, location: "schema.json", api_key: nil, api_key_env_var: nil, proxy: nil)
-      api_key = resolve_api_key(api_key: api_key, api_key_env_var: api_key_env_var)
       proxy = if proxy.nil?
         ENV["AICHAT_PROXY"]&.downcase == "true"
       else
         !!proxy
       end
+      api_key = api_key || ENV.fetch(api_key_env_var || (proxy ? "AICHAT_PROXY_KEY" : "OPENAI_API_KEY"))
       prompt_path = File.expand_path("../prompts/schema_generator.md", __dir__)
       system_prompt = File.read(prompt_path)
 
@@ -75,16 +75,6 @@ module AI
         File.binwrite(location, content)
       end
       content
-    end
-
-    def self.resolve_api_key(api_key: nil, api_key_env_var: nil)
-      return api_key if api_key
-      return ENV.fetch(api_key_env_var) if api_key_env_var
-
-      aichat_api_key = ENV["AICHAT_PROXY_KEY"]
-      return aichat_api_key if aichat_api_key && !aichat_api_key.empty?
-
-      ENV.fetch("OPENAI_API_KEY")
     end
 
     # :reek:TooManyStatements

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -254,7 +254,18 @@ module AI
     private
 
     def resolve_api_key
-      @api_key_arg || ENV.fetch(@api_key_env_var_arg || (@proxy ? PROXY_KEY_ENV : OPENAI_KEY_ENV))
+      env_var = @api_key_env_var_arg || (@proxy ? PROXY_KEY_ENV : OPENAI_KEY_ENV)
+      @api_key_arg || ENV.fetch(env_var) {
+        if @proxy
+          raise KeyError, "Proxy mode is enabled but #{PROXY_KEY_ENV} is not set. " \
+            "Create an environment variable called #{PROXY_KEY_ENV} " \
+            "with your API key from Prepend.me."
+        else
+          raise KeyError, "#{OPENAI_KEY_ENV} is not set. " \
+            "Create an environment variable called #{OPENAI_KEY_ENV} " \
+            "with your API key from https://platform.openai.com/api-keys."
+        end
+      }
     end
 
     class InputClassificationError < StandardError; end
@@ -592,11 +603,11 @@ module AI
     rescue OpenAI::Errors::AuthenticationError
       message = if proxy
         <<~STRING
-          It looks like you're using an invalid API key. Proxying is enabled, so you must use an OpenAI API key from prepend.me. Please disable proxy or update your API key before generating a response.
+          Your API key was not accepted by Prepend.me. Since proxy mode is enabled, you need a valid API key from Prepend.me in the #{PROXY_KEY_ENV} environment variable.
         STRING
       else
         <<~STRING
-          It looks like you're using an invalid API key. Check to make sure your API key is valid before generating a response.
+          Your API key was not accepted by OpenAI. Make sure the #{OPENAI_KEY_ENV} environment variable contains a valid key from https://platform.openai.com/api-keys.
         STRING
       end
       raise WrongAPITokenUsedError, message, cause: nil

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -164,12 +164,20 @@ module AI
     end
 
     def proxy=(value)
-      @proxy = !!value
-      @api_key = resolve_api_key
+      new_proxy = !!value
+      previous_proxy = @proxy
+      @proxy = new_proxy
+      new_key = resolve_api_key
+      client_options = {api_key: new_key}
+      client_options[:base_url] = BASE_PROXY_URL if new_proxy
+      new_client = OpenAI::Client.new(**client_options)
+
+      @api_key = new_key
       @api_key_validated = false
-      client_options = {api_key: @api_key}
-      client_options[:base_url] = BASE_PROXY_URL if @proxy
-      @client = OpenAI::Client.new(**client_options)
+      @client = new_client
+    rescue => error
+      @proxy = previous_proxy
+      raise
     end
 
     def schema=(value)

--- a/spec/integration/ai_chat_integration_spec.rb
+++ b/spec/integration/ai_chat_integration_spec.rb
@@ -230,9 +230,8 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts a custom environment variable name" do
-      preferred_key = ENV["AICHAT_PROXY_KEY"]
-      preferred_key = ENV["OPENAI_API_KEY"] if preferred_key.to_s.empty?
-      ENV["CUSTOM_OPENAI_KEY"] = preferred_key
+      source_var = (ENV["AICHAT_PROXY"]&.downcase == "true") ? "AICHAT_PROXY_KEY" : "OPENAI_API_KEY"
+      ENV["CUSTOM_OPENAI_KEY"] = ENV.fetch(source_var)
 
       chat = AI::Chat.new(api_key_env_var: "CUSTOM_OPENAI_KEY")
       chat.user("Hi")
@@ -243,9 +242,8 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts an API key directly" do
-      api_key = ENV["AICHAT_PROXY_KEY"]
-      api_key = ENV["OPENAI_API_KEY"] if api_key.to_s.empty?
-      chat = AI::Chat.new(api_key: api_key)
+      source_var = (ENV["AICHAT_PROXY"]&.downcase == "true") ? "AICHAT_PROXY_KEY" : "OPENAI_API_KEY"
+      chat = AI::Chat.new(api_key: ENV.fetch(source_var))
       chat.user("Hi")
 
       expect { chat.generate! }.not_to raise_error

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -2,8 +2,12 @@
 
 RSpec.configure do |config|
   config.before(:each, :integration) do
-    if ENV["AICHAT_PROXY_KEY"].to_s.empty? && ENV["OPENAI_API_KEY"].to_s.empty?
-      skip "Integration tests require AICHAT_PROXY_KEY or OPENAI_API_KEY environment variable"
+    if ENV["AICHAT_PROXY"]&.downcase == "true"
+      if ENV["AICHAT_PROXY_KEY"].to_s.empty?
+        skip "Proxy mode is on but AICHAT_PROXY_KEY is not set"
+      end
+    elsif ENV["OPENAI_API_KEY"].to_s.empty?
+      skip "Set OPENAI_API_KEY, or enable proxy mode with AICHAT_PROXY=true and AICHAT_PROXY_KEY"
     end
   end
 end

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -251,6 +251,17 @@ RSpec.describe AI::Chat do
       )
     end
 
+    it "resets API key validation when proxy is toggled" do
+      client_double = instance_double(OpenAI::Client)
+      allow(OpenAI::Client).to receive(:new).and_return(client_double)
+
+      instance = AI::Chat.new(api_key: "test-key")
+      instance.instance_variable_set(:@api_key_validated, true)
+      instance.proxy = true
+
+      expect(instance.instance_variable_get(:@api_key_validated)).to be(false)
+    end
+
     it "allows explicit override to false even when env default is true" do
       with_env_var("AICHAT_PROXY", "true") do
         client_double = instance_double(OpenAI::Client)

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe AI::Chat do
-  let(:chat) { AI::Chat.new }
+  let(:chat) { AI::Chat.new(api_key: "test-key") }
 
   def with_env_var(name, value)
     original = ENV.key?(name) ? ENV[name] : :__undefined__
@@ -193,6 +193,52 @@ RSpec.describe AI::Chat do
       instance.proxy = "anything"
 
       expect(instance.proxy).to be(true)
+    end
+
+    it "re-resolves API key when proxy is toggled on" do
+      with_env_var("OPENAI_API_KEY", "openai-key") do
+        with_env_var("AICHAT_PROXY_KEY", "proxy-key") do
+          client_double = instance_double(OpenAI::Client)
+          allow(OpenAI::Client).to receive(:new).and_return(client_double)
+
+          instance = AI::Chat.new
+          instance.proxy = true
+
+          expect(OpenAI::Client).to have_received(:new).with(
+            api_key: "proxy-key",
+            base_url: AI::Chat::BASE_PROXY_URL
+          )
+        end
+      end
+    end
+
+    it "re-resolves API key when proxy is toggled off" do
+      with_env_var("AICHAT_PROXY", "true") do
+        with_env_var("AICHAT_PROXY_KEY", "proxy-key") do
+          with_env_var("OPENAI_API_KEY", "openai-key") do
+            client_double = instance_double(OpenAI::Client)
+            allow(OpenAI::Client).to receive(:new).and_return(client_double)
+
+            instance = AI::Chat.new
+            instance.proxy = false
+
+            expect(OpenAI::Client).to have_received(:new).with(api_key: "openai-key")
+          end
+        end
+      end
+    end
+
+    it "preserves explicit api_key when proxy is toggled" do
+      client_double = instance_double(OpenAI::Client)
+      allow(OpenAI::Client).to receive(:new).and_return(client_double)
+
+      instance = AI::Chat.new(api_key: "explicit-key")
+      instance.proxy = true
+
+      expect(OpenAI::Client).to have_received(:new).with(
+        api_key: "explicit-key",
+        base_url: AI::Chat::BASE_PROXY_URL
+      )
     end
 
     it "allows explicit override to false even when env default is true" do

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -262,6 +262,24 @@ RSpec.describe AI::Chat do
       expect(instance.instance_variable_get(:@api_key_validated)).to be(false)
     end
 
+    it "does not mutate state when proxy toggle fails" do
+      with_env_var("OPENAI_API_KEY", "openai-key") do
+        with_env_var("AICHAT_PROXY_KEY", nil) do
+          client_double = instance_double(OpenAI::Client)
+          allow(OpenAI::Client).to receive(:new).and_return(client_double)
+
+          instance = AI::Chat.new
+          original_client = instance.client
+          original_api_key = instance.instance_variable_get(:@api_key)
+
+          expect { instance.proxy = true }.to raise_error(KeyError)
+          expect(instance.proxy).to be(false)
+          expect(instance.client).to be(original_client)
+          expect(instance.instance_variable_get(:@api_key)).to eq(original_api_key)
+        end
+      end
+    end
+
     it "allows explicit override to false even when env default is true" do
       with_env_var("AICHAT_PROXY", "true") do
         client_double = instance_double(OpenAI::Client)

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -39,58 +39,58 @@ RSpec.describe AI::Chat do
   end
 
   describe "api key defaults" do
-    it "uses AICHAT_PROXY_KEY before OPENAI_API_KEY by default" do
-      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
+    it "uses OPENAI_API_KEY when proxy is off" do
+      with_env_var("OPENAI_API_KEY", "openai-key") do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
+
+        AI::Chat.new
+      end
+    end
+
+    it "uses AICHAT_PROXY_KEY when proxy is on" do
+      with_env_var("AICHAT_PROXY", "true") do
+        with_env_var("AICHAT_PROXY_KEY", "proxy-key") do
           client_double = instance_double(OpenAI::Client)
-          expect(OpenAI::Client).to receive(:new).with(api_key: "aichat-key").and_return(client_double)
+          expect(OpenAI::Client).to receive(:new).with(
+            api_key: "proxy-key",
+            base_url: AI::Chat::BASE_PROXY_URL
+          ).and_return(client_double)
 
           AI::Chat.new
         end
       end
     end
 
-    it "falls back to OPENAI_API_KEY when AICHAT_PROXY_KEY is missing" do
-      with_env_var("AICHAT_PROXY_KEY", nil) do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
-          client_double = instance_double(OpenAI::Client)
-          expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
-
-          AI::Chat.new
+    it "raises KeyError when proxy is on but AICHAT_PROXY_KEY is missing" do
+      with_env_var("AICHAT_PROXY", "true") do
+        with_env_var("AICHAT_PROXY_KEY", nil) do
+          expect { AI::Chat.new }.to raise_error(KeyError, /AICHAT_PROXY_KEY/)
         end
       end
     end
 
-    it "treats empty AICHAT_PROXY_KEY as missing and falls back to OPENAI_API_KEY" do
-      with_env_var("AICHAT_PROXY_KEY", "") do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
-          client_double = instance_double(OpenAI::Client)
-          expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
-
-          AI::Chat.new
-        end
+    it "raises KeyError when proxy is off but OPENAI_API_KEY is missing" do
+      with_env_var("OPENAI_API_KEY", nil) do
+        expect { AI::Chat.new }.to raise_error(KeyError, /OPENAI_API_KEY/)
       end
     end
 
-    it "uses only the explicitly provided api_key_env_var when present" do
-      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
-        with_env_var("CUSTOM_OPENAI_KEY", "custom-key") do
-          client_double = instance_double(OpenAI::Client)
-          expect(OpenAI::Client).to receive(:new).with(api_key: "custom-key").and_return(client_double)
+    it "uses only the explicitly provided api_key_env_var" do
+      with_env_var("CUSTOM_KEY", "custom-key") do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(api_key: "custom-key").and_return(client_double)
 
-          AI::Chat.new(api_key_env_var: "CUSTOM_OPENAI_KEY")
-        end
+        AI::Chat.new(api_key_env_var: "CUSTOM_KEY")
       end
     end
 
     it "uses explicit api_key before env vars" do
-      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
-          client_double = instance_double(OpenAI::Client)
-          expect(OpenAI::Client).to receive(:new).with(api_key: "direct-key").and_return(client_double)
+      with_env_var("OPENAI_API_KEY", "openai-key") do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(api_key: "direct-key").and_return(client_double)
 
-          AI::Chat.new(api_key: "direct-key")
-        end
+        AI::Chat.new(api_key: "direct-key")
       end
     end
   end
@@ -225,47 +225,44 @@ RSpec.describe AI::Chat do
   end
 
   describe ".generate_schema!" do
-    it "uses AICHAT_PROXY_KEY before OPENAI_API_KEY by default" do
-      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
+    it "uses OPENAI_API_KEY when proxy is off" do
+      with_env_var("OPENAI_API_KEY", "openai-key") do
+        client_double = schema_client_double
+        expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
+
+        AI::Chat.generate_schema!("A tiny schema", location: false)
+      end
+    end
+
+    it "uses AICHAT_PROXY_KEY when proxy is on" do
+      with_env_var("AICHAT_PROXY", "true") do
+        with_env_var("AICHAT_PROXY_KEY", "proxy-key") do
           client_double = schema_client_double
-          expect(OpenAI::Client).to receive(:new).with(api_key: "aichat-key").and_return(client_double)
+          expect(OpenAI::Client).to receive(:new).with(
+            api_key: "proxy-key",
+            base_url: AI::Chat::BASE_PROXY_URL
+          ).and_return(client_double)
 
           AI::Chat.generate_schema!("A tiny schema", location: false)
         end
       end
     end
 
-    it "falls back to OPENAI_API_KEY when AICHAT_PROXY_KEY is empty" do
-      with_env_var("AICHAT_PROXY_KEY", "") do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
-          client_double = schema_client_double
-          expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
+    it "uses only the explicitly provided api_key_env_var" do
+      with_env_var("CUSTOM_KEY", "custom-key") do
+        client_double = schema_client_double
+        expect(OpenAI::Client).to receive(:new).with(api_key: "custom-key").and_return(client_double)
 
-          AI::Chat.generate_schema!("A tiny schema", location: false)
-        end
-      end
-    end
-
-    it "uses only the explicitly provided api_key_env_var when present" do
-      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
-        with_env_var("CUSTOM_OPENAI_KEY", "custom-key") do
-          client_double = schema_client_double
-          expect(OpenAI::Client).to receive(:new).with(api_key: "custom-key").and_return(client_double)
-
-          AI::Chat.generate_schema!("A tiny schema", location: false, api_key_env_var: "CUSTOM_OPENAI_KEY")
-        end
+        AI::Chat.generate_schema!("A tiny schema", location: false, api_key_env_var: "CUSTOM_KEY")
       end
     end
 
     it "uses explicit api_key before env vars" do
-      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
-        with_env_var("OPENAI_API_KEY", "openai-key") do
-          client_double = schema_client_double
-          expect(OpenAI::Client).to receive(:new).with(api_key: "direct-key").and_return(client_double)
+      with_env_var("OPENAI_API_KEY", "openai-key") do
+        client_double = schema_client_double
+        expect(OpenAI::Client).to receive(:new).with(api_key: "direct-key").and_return(client_double)
 
-          AI::Chat.generate_schema!("A tiny schema", location: false, api_key: "direct-key")
-        end
+        AI::Chat.generate_schema!("A tiny schema", location: false, api_key: "direct-key")
       end
     end
 

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -65,14 +65,24 @@ RSpec.describe AI::Chat do
     it "raises KeyError when proxy is on but AICHAT_PROXY_KEY is missing" do
       with_env_var("AICHAT_PROXY", "true") do
         with_env_var("AICHAT_PROXY_KEY", nil) do
-          expect { AI::Chat.new }.to raise_error(KeyError, /AICHAT_PROXY_KEY/)
+          expect { AI::Chat.new }.to raise_error(
+            KeyError,
+            "Proxy mode is enabled but AICHAT_PROXY_KEY is not set. " \
+            "Create an environment variable called AICHAT_PROXY_KEY " \
+            "with your API key from Prepend.me."
+          )
         end
       end
     end
 
     it "raises KeyError when proxy is off but OPENAI_API_KEY is missing" do
       with_env_var("OPENAI_API_KEY", nil) do
-        expect { AI::Chat.new }.to raise_error(KeyError, /OPENAI_API_KEY/)
+        expect { AI::Chat.new }.to raise_error(
+          KeyError,
+          "OPENAI_API_KEY is not set. " \
+          "Create an environment variable called OPENAI_API_KEY " \
+          "with your API key from https://platform.openai.com/api-keys."
+        )
       end
     end
 

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -121,8 +121,22 @@ RSpec.describe AI::Chat do
       end
     end
 
-    it "does not enable proxy for non-exact truthy values" do
+    it "treats AICHAT_PROXY case-insensitively" do
       with_env_var("AICHAT_PROXY", "TRUE") do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(
+          api_key: "test-key",
+          base_url: AI::Chat::BASE_PROXY_URL
+        ).and_return(client_double)
+
+        instance = AI::Chat.new(api_key: "test-key")
+
+        expect(instance.proxy).to be(true)
+      end
+    end
+
+    it "does not enable proxy for non-true env values" do
+      with_env_var("AICHAT_PROXY", "yes") do
         client_double = instance_double(OpenAI::Client)
         expect(OpenAI::Client).to receive(:new).with(api_key: "test-key").and_return(client_double)
 
@@ -130,6 +144,55 @@ RSpec.describe AI::Chat do
 
         expect(instance.proxy).to be(false)
       end
+    end
+
+    it "uses proxy: kwarg over env when proxy: true" do
+      with_env_var("AICHAT_PROXY", nil) do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(
+          api_key: "test-key",
+          base_url: AI::Chat::BASE_PROXY_URL
+        ).and_return(client_double)
+
+        instance = AI::Chat.new(api_key: "test-key", proxy: true)
+
+        expect(instance.proxy).to be(true)
+      end
+    end
+
+    it "uses proxy: kwarg over env when proxy: false" do
+      with_env_var("AICHAT_PROXY", "true") do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(api_key: "test-key").and_return(client_double)
+
+        instance = AI::Chat.new(api_key: "test-key", proxy: false)
+
+        expect(instance.proxy).to be(false)
+      end
+    end
+
+    it "coerces truthy proxy: kwarg to boolean" do
+      with_env_var("AICHAT_PROXY", nil) do
+        client_double = instance_double(OpenAI::Client)
+        expect(OpenAI::Client).to receive(:new).with(
+          api_key: "test-key",
+          base_url: AI::Chat::BASE_PROXY_URL
+        ).and_return(client_double)
+
+        instance = AI::Chat.new(api_key: "test-key", proxy: "false")
+
+        expect(instance.proxy).to be(true)
+      end
+    end
+
+    it "coerces truthy value to boolean in proxy= setter" do
+      client_double = instance_double(OpenAI::Client)
+      allow(OpenAI::Client).to receive(:new).and_return(client_double)
+
+      instance = AI::Chat.new(api_key: "test-key")
+      instance.proxy = "anything"
+
+      expect(instance.proxy).to be(true)
     end
 
     it "allows explicit override to false even when env default is true" do
@@ -239,6 +302,28 @@ RSpec.describe AI::Chat do
 
         AI::Chat.generate_schema!("A tiny schema", api_key: "test-key", location: false, proxy: true)
       end
+    end
+
+    it "treats AICHAT_PROXY case-insensitively" do
+      with_env_var("AICHAT_PROXY", "True") do
+        client_double = schema_client_double
+        expect(OpenAI::Client).to receive(:new).with(
+          api_key: "test-key",
+          base_url: AI::Chat::BASE_PROXY_URL
+        ).and_return(client_double)
+
+        AI::Chat.generate_schema!("A tiny schema", api_key: "test-key", location: false)
+      end
+    end
+
+    it "coerces truthy proxy kwarg to boolean" do
+      client_double = schema_client_double
+      expect(OpenAI::Client).to receive(:new).with(
+        api_key: "test-key",
+        base_url: AI::Chat::BASE_PROXY_URL
+      ).and_return(client_double)
+
+      AI::Chat.generate_schema!("A tiny schema", api_key: "test-key", location: false, proxy: "false")
     end
   end
 


### PR DESCRIPTION
## Summary

- **Add `proxy:` kwarg to `initialize`**, matching `generate_schema!`. No more two-step `new` + setter to override the env default.
- **Eliminate API key fallback chain.** Proxy on → `AICHAT_PROXY_KEY`. Proxy off → `OPENAI_API_KEY`. No silent fallback between the two.
- **`proxy=` setter re-resolves the API key** based on the new proxy mode and resets validation state, so toggling proxy post-construction uses and validates the correct key.
- **Coerce proxy to boolean** with `!!` in initializer, setter, and `generate_schema!`. Prevents `"false"` (a truthy string) from enabling proxy.
- **Case-insensitive `AICHAT_PROXY` env check.** `TRUE`, `True`, etc. now work.
- **Beginner-friendly error messages** for missing env vars (tells you which var to create and where to get a key) and auth failures (names the provider and the env var).
- **Extract env var names into constants** (`PROXY_ENV`, `PROXY_KEY_ENV`, `OPENAI_KEY_ENV`) to eliminate duplicate string literals.
- **Fix `let(:chat)` in unit specs** to use `api_key: "test-key"` so tests don't depend on `OPENAI_API_KEY` being set.
- **Update integration specs** to be proxy-mode-aware instead of using a manual fallback chain.
- **Update README** to describe proxy-aware key resolution, document `proxy:` kwarg, and fix case-sensitivity docs.

Closes #58, closes #59, closes #60

## Test plan

- [x] `OPENAI_API_KEY` used when proxy off, `AICHAT_PROXY_KEY` when proxy on
- [x] `KeyError` with beginner-friendly message when expected env var is missing
- [x] `proxy=` setter re-resolves key and resets validation state
- [x] Explicit `api_key:` preserved across proxy toggles
- [x] Proxy kwarg precedence over env var (both directions)
- [x] Boolean coercion in kwarg, setter, and `generate_schema!`
- [x] Case-insensitive env var matching
- [x] Explicit `api_key:` and `api_key_env_var:` still take precedence
- [x] Auth failure error messages name the provider and env var
- [x] 51 specs, 0 failures