### PR TITLE
Rename AICHAT_API_KEY to AICHAT_PROXY_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Integration API key test fallback**: Updated integration test setup to treat an empty `AICHAT_API_KEY` as missing before falling back to `OPENAI_API_KEY`, matching runtime behavior.
+- **Integration API key test fallback**: Updated integration test setup to treat an empty `AICHAT_PROXY_KEY` as missing before falling back to `OPENAI_API_KEY`, matching runtime behavior.
 
 ## [0.5.7] - 2026-03-02
 
 ### Changed
 
-- **Default API key lookup order**: `AI::Chat.new` and `AI::Chat.generate_schema!` now look for `AICHAT_API_KEY` first, then fall back to `OPENAI_API_KEY` when the first value is missing or empty.
+- **Default API key lookup order**: `AI::Chat.new` and `AI::Chat.generate_schema!` now look for `AICHAT_PROXY_KEY` first, then fall back to `OPENAI_API_KEY` when the first value is missing or empty.
 
 - **Explicit API key override behavior**: Passing `api_key:` still takes highest precedence, and passing `api_key_env_var:` still uses that environment variable exactly.
 
 ### Added
 
-- **Unit coverage for API key precedence**: Added tests covering default env order, empty `AICHAT_API_KEY` fallback, explicit `api_key_env_var:`, and explicit `api_key:` behavior.
+- **Unit coverage for API key precedence**: Added tests covering default env order, empty `AICHAT_PROXY_KEY` fallback, explicit `api_key_env_var:`, and explicit `api_key:` behavior.
 
 ### Updated
 
-- **Integration test setup**: Integration tests now run when either `AICHAT_API_KEY` or `OPENAI_API_KEY` is present.
+- **Integration test setup**: Integration tests now run when either `AICHAT_PROXY_KEY` or `OPENAI_API_KEY` is present.
 
 - **Documentation**: README now documents the new default key lookup order and updates the direct `OpenAI::Client` example to match.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ See [OpenAI's model documentation](https://platform.openai.com/docs/models) for 
 
 ### API key
 
-The gem by default looks for `AICHAT_API_KEY` first. If that is missing (or empty), it falls back to `OPENAI_API_KEY`.
+The gem by default looks for `AICHAT_PROXY_KEY` first. If that is missing (or empty), it falls back to `OPENAI_API_KEY`.
 
 You can specify a different environment variable name:
 
@@ -404,7 +404,7 @@ AI::Chat.generate_schema!("A user profile with name (required), email (required)
 
 This method returns a String containing the JSON schema. The JSON schema also writes (or overwrites) to `schema.json` at the root of the project.
 
-Similar to generating messages with `AI::Chat` objects, this class method will look for `AICHAT_API_KEY` first, then fall back to `OPENAI_API_KEY` if needed. You can also pass the API key directly or choose a different environment variable key for it to use.
+Similar to generating messages with `AI::Chat` objects, this class method will look for `AICHAT_PROXY_KEY` first, then fall back to `OPENAI_API_KEY` if needed. You can also pass the API key directly or choose a different environment variable key for it to use.
 
 ```rb
 # Passing the API key directly
@@ -748,7 +748,7 @@ This is particularly useful for background mode workflows. If you want to retrie
 ```ruby
 require "openai"
 
-api_key = ENV["AICHAT_API_KEY"]
+api_key = ENV["AICHAT_PROXY_KEY"]
 api_key = ENV.fetch("OPENAI_API_KEY") if api_key.nil? || api_key.empty?
 client = OpenAI::Client.new(api_key: api_key)
 

--- a/lib/ai/chat.rb
+++ b/lib/ai/chat.rb
@@ -77,7 +77,7 @@ module AI
       return api_key if api_key
       return ENV.fetch(api_key_env_var) if api_key_env_var
 
-      aichat_api_key = ENV["AICHAT_API_KEY"]
+      aichat_api_key = ENV["AICHAT_PROXY_KEY"]
       return aichat_api_key if aichat_api_key && !aichat_api_key.empty?
 
       ENV.fetch("OPENAI_API_KEY")

--- a/spec/integration/ai_chat_integration_spec.rb
+++ b/spec/integration/ai_chat_integration_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts a custom environment variable name" do
-      preferred_key = ENV["AICHAT_API_KEY"]
+      preferred_key = ENV["AICHAT_PROXY_KEY"]
       preferred_key = ENV["OPENAI_API_KEY"] if preferred_key.to_s.empty?
       ENV["CUSTOM_OPENAI_KEY"] = preferred_key
 
@@ -243,7 +243,7 @@ RSpec.describe "AI::Chat Integration", :integration do
     end
 
     it "accepts an API key directly" do
-      api_key = ENV["AICHAT_API_KEY"]
+      api_key = ENV["AICHAT_PROXY_KEY"]
       api_key = ENV["OPENAI_API_KEY"] if api_key.to_s.empty?
       chat = AI::Chat.new(api_key: api_key)
       chat.user("Hi")

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -2,8 +2,8 @@
 
 RSpec.configure do |config|
   config.before(:each, :integration) do
-    if ENV["AICHAT_API_KEY"].to_s.empty? && ENV["OPENAI_API_KEY"].to_s.empty?
-      skip "Integration tests require AICHAT_API_KEY or OPENAI_API_KEY environment variable"
+    if ENV["AICHAT_PROXY_KEY"].to_s.empty? && ENV["OPENAI_API_KEY"].to_s.empty?
+      skip "Integration tests require AICHAT_PROXY_KEY or OPENAI_API_KEY environment variable"
     end
   end
 end

--- a/spec/unit/chat_spec.rb
+++ b/spec/unit/chat_spec.rb
@@ -32,15 +32,15 @@ RSpec.describe AI::Chat do
 
   around do |example|
     with_env_var("AICHAT_PROXY", nil) do
-      with_env_var("AICHAT_API_KEY", nil) do
+      with_env_var("AICHAT_PROXY_KEY", nil) do
         example.run
       end
     end
   end
 
   describe "api key defaults" do
-    it "uses AICHAT_API_KEY before OPENAI_API_KEY by default" do
-      with_env_var("AICHAT_API_KEY", "aichat-key") do
+    it "uses AICHAT_PROXY_KEY before OPENAI_API_KEY by default" do
+      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = instance_double(OpenAI::Client)
           expect(OpenAI::Client).to receive(:new).with(api_key: "aichat-key").and_return(client_double)
@@ -50,8 +50,8 @@ RSpec.describe AI::Chat do
       end
     end
 
-    it "falls back to OPENAI_API_KEY when AICHAT_API_KEY is missing" do
-      with_env_var("AICHAT_API_KEY", nil) do
+    it "falls back to OPENAI_API_KEY when AICHAT_PROXY_KEY is missing" do
+      with_env_var("AICHAT_PROXY_KEY", nil) do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = instance_double(OpenAI::Client)
           expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
@@ -61,8 +61,8 @@ RSpec.describe AI::Chat do
       end
     end
 
-    it "treats empty AICHAT_API_KEY as missing and falls back to OPENAI_API_KEY" do
-      with_env_var("AICHAT_API_KEY", "") do
+    it "treats empty AICHAT_PROXY_KEY as missing and falls back to OPENAI_API_KEY" do
+      with_env_var("AICHAT_PROXY_KEY", "") do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = instance_double(OpenAI::Client)
           expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
@@ -73,7 +73,7 @@ RSpec.describe AI::Chat do
     end
 
     it "uses only the explicitly provided api_key_env_var when present" do
-      with_env_var("AICHAT_API_KEY", "aichat-key") do
+      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
         with_env_var("CUSTOM_OPENAI_KEY", "custom-key") do
           client_double = instance_double(OpenAI::Client)
           expect(OpenAI::Client).to receive(:new).with(api_key: "custom-key").and_return(client_double)
@@ -84,7 +84,7 @@ RSpec.describe AI::Chat do
     end
 
     it "uses explicit api_key before env vars" do
-      with_env_var("AICHAT_API_KEY", "aichat-key") do
+      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = instance_double(OpenAI::Client)
           expect(OpenAI::Client).to receive(:new).with(api_key: "direct-key").and_return(client_double)
@@ -162,8 +162,8 @@ RSpec.describe AI::Chat do
   end
 
   describe ".generate_schema!" do
-    it "uses AICHAT_API_KEY before OPENAI_API_KEY by default" do
-      with_env_var("AICHAT_API_KEY", "aichat-key") do
+    it "uses AICHAT_PROXY_KEY before OPENAI_API_KEY by default" do
+      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = schema_client_double
           expect(OpenAI::Client).to receive(:new).with(api_key: "aichat-key").and_return(client_double)
@@ -173,8 +173,8 @@ RSpec.describe AI::Chat do
       end
     end
 
-    it "falls back to OPENAI_API_KEY when AICHAT_API_KEY is empty" do
-      with_env_var("AICHAT_API_KEY", "") do
+    it "falls back to OPENAI_API_KEY when AICHAT_PROXY_KEY is empty" do
+      with_env_var("AICHAT_PROXY_KEY", "") do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = schema_client_double
           expect(OpenAI::Client).to receive(:new).with(api_key: "openai-key").and_return(client_double)
@@ -185,7 +185,7 @@ RSpec.describe AI::Chat do
     end
 
     it "uses only the explicitly provided api_key_env_var when present" do
-      with_env_var("AICHAT_API_KEY", "aichat-key") do
+      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
         with_env_var("CUSTOM_OPENAI_KEY", "custom-key") do
           client_double = schema_client_double
           expect(OpenAI::Client).to receive(:new).with(api_key: "custom-key").and_return(client_double)
@@ -196,7 +196,7 @@ RSpec.describe AI::Chat do
     end
 
     it "uses explicit api_key before env vars" do
-      with_env_var("AICHAT_API_KEY", "aichat-key") do
+      with_env_var("AICHAT_PROXY_KEY", "aichat-key") do
         with_env_var("OPENAI_API_KEY", "openai-key") do
           client_double = schema_client_double
           expect(OpenAI::Client).to receive(:new).with(api_key: "direct-key").and_return(client_double)


### PR DESCRIPTION
## Summary

- Rename `AICHAT_API_KEY` env var to `AICHAT_PROXY_KEY` across lib, specs, README, and CHANGELOG
- The old name was ambiguous — it served as both "preferred key" and "proxy key" without indicating which
- `AICHAT_PROXY_KEY` makes the purpose clear (it's the key for the prepend.me proxy) and pairs naturally with `AICHAT_PROXY`

**Breaking change:** Users who have `AICHAT_API_KEY` set in their environment will need to rename it to `AICHAT_PROXY_KEY`.

## Test plan

- [x] `grep -r AICHAT_API_KEY` returns zero hits
- [x] 39 unit specs pass