### PR TITLE
Bump openai dep from ~> 0.43 to ~> 0.59

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)
       marcel (~> 1.0)
-      openai (~> 0.43)
+      openai (~> 0.59)
       tty-spinner (~> 0.9.3)
 
 GEM
@@ -66,7 +66,7 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     marcel (1.1.0)
-    openai (0.43.0)
+    openai (0.59.0)
       base64
       cgi
       connection_pool

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = ">= 3.2"
-  spec.add_runtime_dependency "openai", "~> 0.43"
+  spec.add_runtime_dependency "openai", "~> 0.59"
   spec.add_runtime_dependency "marcel", "~> 1.0"
   spec.add_runtime_dependency "base64", "~> 0.1", "> 0.1.1"
   spec.add_runtime_dependency "json", "~> 2.0"


### PR DESCRIPTION
## Summary

- Bumps `openai` from `~> 0.43` to `~> 0.59` in `ai-chat.gemspec`, refreshes `Gemfile.lock` (`0.43.0` → `0.59.0`).
- No `lib/` changes are required — every method the gem calls keeps the same signature, and the response shape it consumes (`id` / `output` / `output_text` / `model` / `usage` / `image_generation_call` items) is unchanged.

## What we pick up

- **Typed `action` field on the `image_generation` tool** (auto/generate/edit), added after 0.43. Unknown keys were already passing through `BaseModel.coerce`/`dump`, so nothing depended on this — but the SDK surface is now closer to OpenAI's docs.
- **`gpt-5.4` mini/nano model slugs** in `ChatModel` (added in 0.56.0).
- **Short-lived tokens, `phase` field on Conversations messages, `WEB_SEARCH_CALL_RESULTS` in `ResponseIncludable`** (0.57–0.58). Not used in `lib/` today, but available.
- **Assorted fixes**: RFC 3986 path encoding, multipart form-field name encoding, multipart array-field encoding.

There is still no typed `gpt-image-2` constant — the announcement landed 2026-04-21, one week after openai-ruby 0.59.0 shipped. The tool's `model` field is a `String|Symbol` union, so `"gpt-image-2"` already passes through.

## Test plan

- [x] `bundle exec rspec spec/unit` — 72 examples, 0 failures under 0.59.0
- [x] `bundle exec standardrb lib/ ai-chat.gemspec` — clean on the diff (two pre-existing warnings at `lib/ai/chat.rb:49` and `:178` are unrelated)
- [x] Gem loads cleanly under the new SDK (`bundle exec ruby -e 'require "ai-chat"'`)
- [ ] Integration smoke test against real API — leaving to the reviewer since it costs credits

## Relates to

#64 (image_generation Hash options) will be rebased on top of this branch so reviewers can see a clean diff.