### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.1] - 2026-04-22
 
 ### Added
 
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`image_generation=` validates its argument**: Only `true`, `false`, `nil`, or a `Hash` are now accepted. `nil` is normalized to `false`. Any other value raises `ArgumentError`.
+- **`image_generation=` validates its argument**: Only `true`, `false`, `nil`, or a `Hash` are now accepted. `nil` is normalized to `false`. Any other value raises `ArgumentError`. (Technically breaking: values like truthy strings or integers that silently worked before now raise.)
+
+- **Bumped `openai` runtime dependency from `~> 0.43` to `~> 0.59`**: Picks up the typed `action` field on the image_generation tool, `gpt-5.4` mini/nano model slugs, and assorted upstream SDK transport fixes. No gem code changes were required for the bump — every method we call kept the same signature.
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.6.0)
+    ai-chat (0.6.1)
       amazing_print (~> 2.0)
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ai-chat"
-  spec.version = "0.6.0"
+  spec.version = "0.6.1"
   spec.authors = ["Raghu Betina", "Jelani Woods"]
   spec.email = ["raghu@firstdraft.com", "jelani@firstdraft.com"]
   spec.homepage = "https://github.com/firstdraft/ai-chat"


### PR DESCRIPTION
## Summary

- `ai-chat.gemspec`: version `0.6.0` → `0.6.1`
- `CHANGELOG.md`: `[Unreleased]` → `[0.6.1] - 2026-04-22`; added an entry for the openai `~> 0.43` → `~> 0.59` bump (it merged as its own PR, so it wasn't in the original `[Unreleased]` block) and flagged the stricter `image_generation=` validation as technically breaking.

## Why patch

Pre-1.0, and the only behavioral shrinkage is `image_generation=` now rejecting values that were never documented as supported (truthy strings, integers, arrays). The main change — the new `Hash` surface on `image_generation=` — is purely additive; `chat.image_generation = true` works exactly as before.

## Live smoke test

Ran before cutting this release (`tmp/smoke_test.rb`, gitignored):

- `{size: "1024x1024", quality: "low"}` → PNG saved to `./tmp/smoke_test_images/.../001.png`, 1,082,515 bytes.
- `{size: "1024x1024", quality: "low", output_format: "jpeg"}` → file saved to `.../001.jpg` (not `.png`), 48,190 bytes, magic bytes `ff d8 ff` confirm real JPEG content. Validates the Marcel-sniffing extension fix end-to-end.

## After merge

1. `git pull` on main
2. `git tag v0.6.1 && git push --tags`
3. `gem build ai-chat.gemspec`
4. `gem push ai-chat-0.6.1.gem` — requires MFA, yours to run