### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-08-24
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ai-chat (0.6.1)
+    ai-chat (0.7.0)
       amazing_print (~> 2.0)
       base64 (~> 0.1, > 0.1.1)
       json (~> 2.0)

--- a/ai-chat.gemspec
+++ b/ai-chat.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ai-chat"
-  spec.version = "0.6.1"
+  spec.version = "0.7.0"
   spec.authors = ["Raghu Betina", "Jelani Woods"]
   spec.email = ["raghu@firstdraft.com", "jelani@firstdraft.com"]
   spec.homepage = "https://github.com/firstdraft/ai-chat"


### PR DESCRIPTION
Bumps version to 0.7.0 and dates the CHANGELOG entry. Contents: #67 (default model gpt-5.6-terra, reasoning_effort default "none", Ruby >= 3.3, openai ~> 0.80).